### PR TITLE
Only report gauges when they change

### DIFF
--- a/signalfx-codahale/src/main/java/com/signalfx/codahale/metrics/SettableDoubleGauge.java
+++ b/signalfx-codahale/src/main/java/com/signalfx/codahale/metrics/SettableDoubleGauge.java
@@ -1,7 +1,7 @@
 package com.signalfx.codahale.metrics;
 
-import com.codahale.metrics.Gauge;
 import com.codahale.metrics.Metric;
+import com.signalfx.codahale.reporter.SettableGauge;
 
 /**
  * <p>
@@ -9,18 +9,19 @@ import com.codahale.metrics.Metric;
  * is set when needed.  This can be somewhat convienent, but direct use of a Gauge is likely better
  * </p>
  * <p>
- *     Usage example:
- *     <pre>{@code
- *       MetricRegister metricRegistry;
- *       SettableDoubleGauge settable = metricRegistry.register("metric.name", new SettableDoubleGauge());
- *       // ...
- *       settable.setValue(1.234);
- *       // ...
- *       settable.setValue(3.156);
- *     }
- *     </pre>
+ * Usage example:
+ * </p>
+ * <pre>{@code
+ *   MetricRegister metricRegistry;
+ *   SettableDoubleGauge settable = metricRegistry.register("metric.name", new SettableDoubleGauge());
+ *   // ...
+ *   settable.setValue(1.234);
+ *   // ...
+ *   settable.setValue(3.156);
+ * }
+ * </pre>
  */
-public class SettableDoubleGauge implements Metric, Gauge<Double> {
+public class SettableDoubleGauge extends SettableGauge<Double> {
     /**
      * Current value.  Assignment will be atomic.  <a href="http://docs.oracle.com/javase/specs/jls/se7/html/jls-17.html#jls-17.7">See 17.7</a>
      */
@@ -33,6 +34,7 @@ public class SettableDoubleGauge implements Metric, Gauge<Double> {
      */
     public SettableDoubleGauge setValue(double value) {
         this.value = value;
+        markSet();
         return this;
     }
 
@@ -43,7 +45,6 @@ public class SettableDoubleGauge implements Metric, Gauge<Double> {
     public Double getValue() {
         return value;
     }
-
 
     public final static class Builder implements MetricBuilder<SettableDoubleGauge> {
         public static final Builder INSTANCE = new Builder();

--- a/signalfx-codahale/src/main/java/com/signalfx/codahale/metrics/SettableLongGauge.java
+++ b/signalfx-codahale/src/main/java/com/signalfx/codahale/metrics/SettableLongGauge.java
@@ -1,7 +1,7 @@
 package com.signalfx.codahale.metrics;
 
-import com.codahale.metrics.Gauge;
 import com.codahale.metrics.Metric;
+import com.signalfx.codahale.reporter.SettableGauge;
 
 /**
  * <p>
@@ -9,19 +9,19 @@ import com.codahale.metrics.Metric;
  * is set when needed.  This can be somewhat convienent, but direct use of a Gauge is likely better
  * </p>
  * <p>
- *     Usage example:
- *     <pre>{@code
- *       MetricRegister metricRegistry;
- *       SettableLongGauge settable = metricRegistry.register("metric.name", new SettableLongGauge());
- *       // ...
- *       settable.setValue(100);
- *       // ...
- *       settable.setValue(200);
- *     }
- *
- *     </pre>
+ * Usage example:
+ * </p>
+ * <pre>{@code
+ *   MetricRegister metricRegistry;
+ *   SettableLongGauge settable = metricRegistry.register("metric.name", new SettableLongGauge());
+ *   // ...
+ *   settable.setValue(100);
+ *   // ...
+ *   settable.setValue(200);
+ * }
+ * </pre>
  */
-public class SettableLongGauge implements Metric, Gauge<Long> {
+public class SettableLongGauge extends SettableGauge<Long> {
     /**
      * Current value.  Assignment will be atomic.  <a href="http://docs.oracle.com/javase/specs/jls/se7/html/jls-17.html#jls-17.7">See 17.7</a>
      */
@@ -34,6 +34,7 @@ public class SettableLongGauge implements Metric, Gauge<Long> {
      */
     public SettableLongGauge setValue(long value) {
         this.value = value;
+        markSet();
         return this;
     }
 

--- a/signalfx-codahale/src/main/java/com/signalfx/codahale/reporter/SettableGauge.java
+++ b/signalfx-codahale/src/main/java/com/signalfx/codahale/reporter/SettableGauge.java
@@ -1,0 +1,34 @@
+package com.signalfx.codahale.reporter;
+
+import com.codahale.metrics.Gauge;
+import com.codahale.metrics.Metric;
+
+import java.util.concurrent.atomic.AtomicLong;
+
+public abstract class SettableGauge<T> implements Metric, Gauge<T> {
+
+    private final AtomicLong lastSet = new AtomicLong();
+    private volatile long lastReported = 0;
+
+    /**
+     * Mark the gauge has having been set.
+     */
+    protected void markSet() {
+        lastSet.incrementAndGet();
+    }
+
+    /**
+     * Mark the gauge has having been reported.
+     */
+    void markReported() {
+        lastReported = lastSet.get();
+    }
+
+    /**
+     * @return Returns <em>true</em> iff the gauge's value has been set since the last time it was
+     *      reported.
+     */
+    boolean hasChanged() {
+        return lastSet.get() > lastReported;
+    }
+}

--- a/signalfx-codahale/src/test/java/com/signalfx/codahale/reporter/SettableGaugeTest.java
+++ b/signalfx-codahale/src/test/java/com/signalfx/codahale/reporter/SettableGaugeTest.java
@@ -1,0 +1,38 @@
+package com.signalfx.codahale.reporter;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import org.junit.Test;
+
+import com.signalfx.codahale.metrics.SettableLongGauge;
+
+public class SettableGaugeTest {
+
+    @Test
+    public void testHasChanged() {
+        SettableGauge gauge = new SettableLongGauge();
+        assertFalse(gauge.hasChanged());
+
+        ((SettableLongGauge) gauge).setValue(42L);
+        assertTrue(gauge.hasChanged());
+    }
+
+    @Test
+    public void testMarks() {
+        SettableGauge gauge = new SettableLongGauge();
+        assertFalse(gauge.hasChanged());
+
+        gauge.markReported();
+        assertFalse(gauge.hasChanged());
+
+        gauge.markSet();
+        assertTrue(gauge.hasChanged());
+
+        gauge.markReported();
+        assertFalse(gauge.hasChanged());
+
+        gauge.markSet();
+        gauge.markReported();
+        assertFalse(gauge.hasChanged());
+    }
+}


### PR DESCRIPTION
For Settable{Double,Long}Gauge, only report them to SignalFx when they
their value has been set since the last time we reported them.

**Note:** I need to test this more thoroughly locally before you merge it, but I want a second (or more) pair of eyes on it too.