### PR TITLE
Updated maven dependencies to replace codahale with dropwizard

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -183,9 +183,9 @@
         <version>2.2.2</version>
       </dependency>
       <dependency>
-        <groupId>com.codahale.metrics</groupId>
+        <groupId>io.dropwizard.metrics</groupId>
         <artifactId>metrics-core</artifactId>
-        <version>3.0.2</version>
+        <version>3.1.2</version>
       </dependency>
       <dependency>
         <groupId>com.yammer.metrics</groupId>

--- a/signalfx-codahale/pom.xml
+++ b/signalfx-codahale/pom.xml
@@ -15,7 +15,7 @@
   <version>0.0.25-SNAPSHOT</version>
   <packaging>jar</packaging>
   <description>
-    Codahale yammer metrics plugin for signalfx
+    Dropwizard Codahale metrics plugin for signalfx
   </description>
 
   <url>http://www.signalfx.com</url>
@@ -63,7 +63,7 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>com.codahale.metrics</groupId>
+      <groupId>io.dropwizard.metrics</groupId>
       <artifactId>metrics-core</artifactId>
     </dependency>
     <dependency>


### PR DESCRIPTION
I use the maven duplicate finder plugin, and my build fails when I use dropwizard's `metrics-core` in my app, and include `signalfx-codahale` to use the reporter.  I was getting this error/warning:
```
[INFO] --- duplicate-finder-maven-plugin:1.2.1:check (default) @ common ---
[INFO] Checking compile classpath
[INFO] Checking runtime classpath
[INFO] Checking test classpath
[WARNING] Found duplicate (but equal) classes in [com.codahale.metrics:metrics-core:3.0.2, io.dropwizard.metrics:metrics-core:3.1.2]:
[WARNING]   com.codahale.metrics.CachedGauge
[WARNING]   com.codahale.metrics.Clock
[WARNING]   com.codahale.metrics.Counter
[WARNING]   com.codahale.metrics.Counting
[WARNING]   com.codahale.metrics.DerivativeGauge
[WARNING]   com.codahale.metrics.EWMA
[WARNING]   com.codahale.metrics.Gauge
[WARNING]   com.codahale.metrics.Histogram
[WARNING]   com.codahale.metrics.Meter
[WARNING]   com.codahale.metrics.Metered
[WARNING]   com.codahale.metrics.Metric
[WARNING]   com.codahale.metrics.MetricRegistryListener
[WARNING]   com.codahale.metrics.MetricSet
[WARNING]   com.codahale.metrics.RatioGauge
[WARNING]   com.codahale.metrics.Reservoir
[WARNING]   com.codahale.metrics.Sampling
[WARNING]   com.codahale.metrics.SharedMetricRegistries
```
