### PR TITLE
Support expired-tsid stream message

### DIFF
--- a/signalfx-java/src/main/java/com/signalfx/signalflow/ChannelMessage.java
+++ b/signalfx-java/src/main/java/com/signalfx/signalflow/ChannelMessage.java
@@ -39,6 +39,7 @@ public abstract class ChannelMessage {
         END_OF_CHANNEL(Kind.CONTROL),
         INFO_MESSAGE(Kind.INFORMATION),
         METADATA_MESSAGE(Kind.METADATA),
+        EXPIRED_TSID_MESSAGE(Kind.EXPIRED_TSID),
         DATA_MESSAGE(Kind.DATA),
         EVENT_MESSAGE(Kind.EVENT),
         ERROR_MESSAGE(Kind.ERROR);
@@ -98,6 +99,10 @@ public abstract class ChannelMessage {
 
             case METADATA:
                 message = mapper.readValue(streamMessage.getData(), MetadataMessage.class);
+                break;
+
+            case EXPIRED_TSID:
+                message = mapper.readValue(streamMessage.getData(), ExpiredTsIdMessage.class);
                 break;
 
             case DATA:
@@ -289,6 +294,28 @@ public abstract class ChannelMessage {
          */
         public Map<String, Object> getProperties() {
             return this.properties;
+        }
+    }
+
+    /**
+     * Message informing us that an output timeseries is no longer
+     * part of the computation and that we may do some cleanup of
+     * whatever internal state we have tied to that output timeseries.
+    */
+    public static class ExpiredTsIdMessage extends ChannelMessage {
+
+        protected String tsId;
+
+        public ExpiredTsIdMessage() {
+            this.channelMessageType = Type.EXPIRED_TSID_MESSAGE;
+        }
+
+        /**
+         * @return The identifier of the timeseries that's no longer interesting
+         *         to the computation.
+         */
+        public String getTsId() {
+            return this.tsId;
         }
     }
 

--- a/signalfx-java/src/main/java/com/signalfx/signalflow/Computation.java
+++ b/signalfx-java/src/main/java/com/signalfx/signalflow/Computation.java
@@ -16,6 +16,7 @@ import java.util.NoSuchElementException;
 import com.signalfx.signalflow.ChannelMessage.ChannelAbortMessage;
 import com.signalfx.signalflow.ChannelMessage.DataMessage;
 import com.signalfx.signalflow.ChannelMessage.ErrorMessage;
+import com.signalfx.signalflow.ChannelMessage.ExpiredTsIdMessage;
 import com.signalfx.signalflow.ChannelMessage.InfoMessage;
 import com.signalfx.signalflow.ChannelMessage.JobStartMessage;
 import com.signalfx.signalflow.ChannelMessage.MetadataMessage;
@@ -268,10 +269,15 @@ public class Computation implements Iterable<ChannelMessage>, Iterator<ChannelMe
 
                 case METADATA_MESSAGE:
                     // Intercept metadata messages to accumulate received metadata.
-                    // TODO(dgriff): this can accumulate metadata without bounds if a computation
-                    // has a high rate of member churn.
                     MetadataMessage metadataMessage = (MetadataMessage) message;
                     metadata.put(metadataMessage.getTsId(), metadataMessage.getProperties());
+                    this.nextMessage = message;
+                    break;
+
+                case EXPIRED_TSID_MESSAGE:
+                    // Intercept expired-tsid messages to clean it up.
+                    ExpiredTsIdMessage expiredTsIdMessage = (ExpiredTsIdMessage) message;
+                    this.metadata.remove(expiredTsIdMessage.getTsId());
                     this.nextMessage = message;
                     break;
 

--- a/signalfx-java/src/main/java/com/signalfx/signalflow/StreamMessage.java
+++ b/signalfx-java/src/main/java/com/signalfx/signalflow/StreamMessage.java
@@ -25,7 +25,8 @@ public class StreamMessage {
         EVENT("event",(byte) 3),
         METADATA("metadata",(byte) 4),
         DATA("data",(byte) 5),
-        ERROR("error",(byte) 6);
+        ERROR("error",(byte) 6),
+        EXPIRED_TSID("expired-tsid",(byte) 10);
 
         private final String specName;
         private final byte type;


### PR DESCRIPTION
New stream message type expired-tsid tells us about timeseries that are
no longer interesting in the computation (if they do re-appear, we'll
get new metadata for them). We use this message to remove entries from
the computation object's internal metadata storage map.