### PR TITLE
signalfx-codahale: allow metrics to be removed from metadata/registry

### DIFF
--- a/signalfx-codahale/src/main/java/com/signalfx/codahale/reporter/MetricMetadata.java
+++ b/signalfx-codahale/src/main/java/com/signalfx/codahale/reporter/MetricMetadata.java
@@ -38,6 +38,14 @@ public interface MetricMetadata {
      */
     public <M extends Metric> BuilderTagger<M> forBuilder(MetricBuilder<M> metricBuilder);
 
+    /**
+     * Removes the specified metric from the metric metadata and registry.
+     * @param metric           The metric to remove, cannot be null.
+     * @param metricRegistry   Registry to remove the metric from 
+     * @return True if the metric was found and removed, false otherwise
+     */
+    public <M extends Metric> boolean removeMetric(M metric, MetricRegistry metricRegistry);
+
     public interface TaggerBase<M extends Metric, T extends TaggerBase<M, ?>> {
         /**
          *  Tag the metric with a sf_source
@@ -46,6 +54,7 @@ public interface MetricMetadata {
          * @deprecated The use of the build in source parameter is deprecated and discouraged.  Use
          *             {@link #withDimension(String, String)} instead.
          */
+        @Deprecated
         T withSourceName(String sourceName);
 
         /**

--- a/signalfx-codahale/src/test/java/com/signalfx/codahale/metrics/MetricMetadataTest.java
+++ b/signalfx-codahale/src/test/java/com/signalfx/codahale/metrics/MetricMetadataTest.java
@@ -1,0 +1,41 @@
+/**
+ * Copyright (C) 2017 SignalFx, Inc.  All rights reserved.
+ */
+package com.signalfx.codahale.metrics;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+import com.codahale.metrics.Counter;
+import com.codahale.metrics.Metric;
+import com.codahale.metrics.MetricRegistry;
+import com.signalfx.codahale.reporter.MetricMetadata;
+import com.signalfx.codahale.reporter.MetricMetadataImpl;
+import com.signalfx.metrics.protobuf.SignalFxProtocolBuffers.MetricType;
+
+public class MetricMetadataTest {
+
+    @Test
+    public void testRemoveExisting() {
+        MetricRegistry metricRegistry = new MetricRegistry();
+        MetricMetadata metadata = new MetricMetadataImpl();
+        Metric metric = metadata.forBuilder(SettableLongGauge.Builder.INSTANCE)
+                .withMetricName("gauge").withDimension("host", "myhost")
+                .withMetricType(MetricType.GAUGE).createOrGet(metricRegistry);
+        assertFalse(metricRegistry.getMetrics().isEmpty());
+        assertTrue(metadata.getMetricType(metric).isPresent());
+        assertTrue(metadata.removeMetric(metric, metricRegistry));
+        assertFalse(metadata.getMetricType(metric).isPresent());
+        assertTrue(metricRegistry.getMetrics().isEmpty());
+    }
+
+    @Test
+    public void testRemoveMissing() {
+        MetricRegistry metricRegistry = new MetricRegistry();
+        MetricMetadata metadata = new MetricMetadataImpl();
+        Counter counter = metricRegistry.counter("counter");
+        assertFalse(metadata.removeMetric(counter, metricRegistry));
+    }
+}

--- a/signalfx-yammer/src/main/java/com/signalfx/codahale/reporter/MetricMetadata.java
+++ b/signalfx-yammer/src/main/java/com/signalfx/codahale/reporter/MetricMetadata.java
@@ -2,7 +2,6 @@ package com.signalfx.codahale.reporter;
 
 import java.util.Map;
 import com.yammer.metrics.core.Metric;
-import com.yammer.metrics.core.MetricsRegistry;
 import com.google.common.base.Optional;
 import com.signalfx.metrics.protobuf.SignalFxProtocolBuffers;
 
@@ -28,6 +27,13 @@ public interface MetricMetadata {
     @Deprecated
     public <M extends Metric> Tagger<M> tagMetric(M metric);
 
+    /**
+     * Removes the specified metric from the metric metadata.
+     * @param metric           The metric to remove, cannot be null.
+     * @return True if the metric was found and removed, false otherwise
+     */
+    public <M extends Metric> boolean removeMetric(M metric);
+
     public interface TaggerBase<M extends Metric, T extends TaggerBase<M, ?>> {
         /**
          *  Tag the metric with a sf_source
@@ -36,6 +42,7 @@ public interface MetricMetadata {
          * @deprecated The use of the build in source parameter is deprecated and discouraged.  Use
          *             {@link #withDimension(String, String)} instead.
          */
+        @Deprecated
         T withSourceName(String sourceName);
 
         /**


### PR DESCRIPTION
Add a method that takes care of properly removing a metric from the
metric metadata and registry.

Test Plan: unit test