### PR TITLE
Upgrading protobuf to 3.4.0 to match sf-base

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,6 +21,7 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <protobuf.version>3.4.0</protobuf.version>
   </properties>
 
   <url>http://www.signalfx.com</url>
@@ -210,7 +211,7 @@
       <dependency>
         <groupId>com.google.protobuf</groupId>
         <artifactId>protobuf-java</artifactId>
-        <version>2.5.0</version>
+        <version>${protobuf.version}</version>
       </dependency>
       <dependency>
         <groupId>org.apache.httpcomponents</groupId>

--- a/signalfx-commons-protoc-java/pom.xml
+++ b/signalfx-commons-protoc-java/pom.xml
@@ -60,7 +60,6 @@
     <dependency>
       <groupId>com.google.protobuf</groupId>
       <artifactId>protobuf-java</artifactId>
-      <version>2.5.0</version>
     </dependency>
     <dependency>
       <groupId>commons-io</groupId>

--- a/signalfx-protoc/pom.xml
+++ b/signalfx-protoc/pom.xml
@@ -54,11 +54,16 @@
   <build>
     <plugins>
       <plugin>
-        <groupId>com.comoyo.maven.plugins</groupId>
-        <artifactId>protoc-bundled-plugin</artifactId>
-        <version>1.4.46</version>
+        <groupId>com.github.os72</groupId>
+        <artifactId>protoc-jar-maven-plugin</artifactId>
+        <version>3.4.0.1</version>
         <executions>
           <execution>
+            <configuration>
+              <protocVersion>${protobuf.version}</protocVersion>
+              <includeStdTypes>true</includeStdTypes>
+            </configuration>
+            <phase>generate-sources</phase>
             <goals>
               <goal>run</goal>
             </goals>

--- a/signalfx-protoc/src/main/protobuf/signal_fx_protocol_buffers.proto
+++ b/signalfx-protoc/src/main/protobuf/signal_fx_protocol_buffers.proto
@@ -1,3 +1,5 @@
+syntax = "proto2";
+
 package com.signalfx.metrics.protobuf;
 
 enum MetricType {


### PR DESCRIPTION
Protobuf schemas will still be compiled as v2 and will be compatible with v2 parsers