### PR TITLE
Use shaded protobuf 3.5.1 library from com.github.os72

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,10 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <protobuf.version>3.5.0</protobuf.version>
+    <protobuf.version>3.5.1</protobuf.version>
+    <os72.protobuf-shaded.version>351</os72.protobuf-shaded.version>
+    <os72.protobuf-shaded.jar-version>0.9</os72.protobuf-shaded.jar-version>
+    <os72.protobuf-shaded.plugin-version>${protobuf.version}.1</os72.protobuf-shaded.plugin-version>
   </properties>
 
   <url>http://www.signalfx.com</url>
@@ -209,9 +212,9 @@
         <version>1.1.0.Final</version>
       </dependency>
       <dependency>
-        <groupId>com.google.protobuf</groupId>
-        <artifactId>protobuf-java</artifactId>
-        <version>${protobuf.version}</version>
+        <groupId>com.github.os72</groupId>
+        <artifactId>protobuf-java-shaded-${os72.protobuf-shaded.version}</artifactId>
+        <version>${os72.protobuf-shaded.jar-version}</version>
       </dependency>
       <dependency>
         <groupId>org.apache.httpcomponents</groupId>

--- a/signalfx-commons-protoc-java/pom.xml
+++ b/signalfx-commons-protoc-java/pom.xml
@@ -44,8 +44,8 @@
 
   <dependencies>
     <dependency>
-      <groupId>com.google.protobuf</groupId>
-      <artifactId>protobuf-java</artifactId>
+      <groupId>com.github.os72</groupId>
+      <artifactId>protobuf-java-shaded-${os72.protobuf-shaded.version}</artifactId>
     </dependency>
 
     <dependency>

--- a/signalfx-commons-protoc-java/src/main/java/com/signalfx/common/proto/ProtocolBufferStreamingInputStream.java
+++ b/signalfx-commons-protoc-java/src/main/java/com/signalfx/common/proto/ProtocolBufferStreamingInputStream.java
@@ -3,7 +3,7 @@ package com.signalfx.common.proto;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.Iterator;
-import com.google.protobuf.MessageLite;
+import com.github.os72.protobuf351.MessageLite;
 
 /**
  * The idea with this class is that we can encapsulate a collection of protocol buffers and send
@@ -26,7 +26,7 @@ public final class ProtocolBufferStreamingInputStream<ProtocolBufferObject exten
      * Fill in our byte buffer if we're out of space by reading the next protocol buffer object.
      *
      * @throws IOException
-     *         If {@link com.google.protobuf.MessageLite#writeDelimitedTo(java.io.OutputStream)}
+     *         If {@link MessageLite#writeDelimitedTo(java.io.OutputStream)}
      *         fails
      */
     private void fillBytes() throws IOException {

--- a/signalfx-commons-protoc-java/src/test/java/com/signalfx/metrics/metric/ProtoBufTest.java
+++ b/signalfx-commons-protoc-java/src/test/java/com/signalfx/metrics/metric/ProtoBufTest.java
@@ -14,7 +14,7 @@ import java.util.List;
 import org.apache.commons.io.IOUtils;
 import org.junit.Test;
 
-import com.google.protobuf.InvalidProtocolBufferException;
+import com.github.os72.protobuf351.InvalidProtocolBufferException;
 import com.signalfx.common.proto.ProtocolBufferStreamingInputStream;
 import com.signalfx.metrics.protobuf.SignalFxProtocolBuffers.DataPoint;
 import com.signalfx.metrics.protobuf.SignalFxProtocolBuffers.Datum;

--- a/signalfx-protoc/pom.xml
+++ b/signalfx-protoc/pom.xml
@@ -46,8 +46,8 @@
 
   <dependencies>
     <dependency>
-      <groupId>com.google.protobuf</groupId>
-      <artifactId>protobuf-java</artifactId>
+      <groupId>com.github.os72</groupId>
+      <artifactId>protobuf-java-shaded-${os72.protobuf-shaded.version}</artifactId>
     </dependency>
   </dependencies>
 
@@ -56,17 +56,17 @@
       <plugin>
         <groupId>com.github.os72</groupId>
         <artifactId>protoc-jar-maven-plugin</artifactId>
-        <version>3.4.0.1</version>
+        <version>${os72.protobuf-shaded.plugin-version}</version>
         <executions>
           <execution>
-            <configuration>
-              <protocVersion>${protobuf.version}</protocVersion>
-              <includeStdTypes>true</includeStdTypes>
-            </configuration>
             <phase>generate-sources</phase>
             <goals>
               <goal>run</goal>
             </goals>
+            <configuration>
+              <protocVersion>${protobuf.version}</protocVersion>
+              <type>java-shaded</type>
+            </configuration>
           </execution>
         </executions>
       </plugin>


### PR DESCRIPTION
With this change SignalFx Java libraries no longer impose whatever version of ProtocolBuffers we use on the rest of the application.