### PR TITLE
Send compressed datapoints payload by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,42 +182,6 @@ try {
 After setting up a SignalFxReporter, you can use Codahale metrics as you
 normally would, reported at the frequency configured by the `SignalFxReporter`.
 
-### Default Dimensions
-
-Sometimes there is a desire to set one or more dimension key/value pairs
-on every datapoint that is reported by this library. In order to do this
-call `addDimension(String key, String value)` or
-`addDimensions(Map<String,String> dimensions)` on the `SignalFxReport.Builder`
-object. Note that if IncrementalCounter is used to create a distributed
-counter you will want to make sure that none of the dimensions passed
-to addDimension/addDimensions are unique to the reporting source
-(e.g. hostname, AWSUniqueId) as this will make make the counter
-non-distributed. For such dimensions use `addUniqueDimensions/addUniqueDimension`
-on the `SignalFxReport.Builder` object.
-
-### AWS Integration
-
-To enable AWS integration in SignalFx (i.e aws tag/property syncing) to a metric
-you can use `com.signalfx.metrics.aws.AWSInstanceInfo`. And either add it as
-a dimension in `MetricMetadata` or add it as a default dimension.
-
-```java
-String instanceInfo = AWSInstanceInfo.get()
-Timer t = metricMetadata
-    .forBuilder(MetricBuilder.TIMERS)
-    .withMetricName("request_time")
-    .withDimension(AWSInstanceInfo.DIMENSION_NAME, instanceInfo)
-    .createOrGet(metricRegistery);
-
-/**
- * As default dimension
- */
-final SignalFxReporter signalfxReporter = new SignalFxReporter.Builder(
-    metricRegistry,
-    "SIGNALFX_AUTH_TOKEN"
-).addUniqueDimension(AWSInstanceInfo.DIMENSION_NAME, instanceInfo).build();
-```
-
 ### Yammer Metrics
 
 You can also use this library with Yammer metrics 2.0.x as shown in the
@@ -267,7 +231,7 @@ metricMetadata.forMetric(gauge)
     .withDimension("queue_name", "customer_backlog");
 ```
 
-#### 4. Adding Dimensions without knowing if they already exist
+#### 4. Adding dimensions without knowing if they already exist
 
 This is not supported in Yammer Metrics 2.0.x.
 
@@ -288,18 +252,27 @@ final SignalFxReporter signalfxReporter = new SignalFxReporter.Builder(
 ).build();
 ```
 
-## Default Dimensions
+### Default dimensions
 
-Sometimes there is a desire to set one or more dimension key/value pairs on
-every datapoint that is reported by this library. In order to do this call
-`addDimension(String key, String value)` or `addDimensions(Map<String,String>
-dimensions)` on the `SignalFxReport.Builder` object.
+Sometimes there is a desire to set one or more dimension key/value pairs
+on every datapoint that is reported by this library. In order to do this
+call `addDimension(String key, String value)` or
+`addDimensions(Map<String,String> dimensions)` on the
+`SignalFxReporter.Builder` object.
+
+Note that if `IncrementalCounter` is used to create a distributed
+counter you will want to make sure that none of the dimensions passed to
+`addDimension()/addDimensions()` are unique to the reporting source
+(e.g. `hostname`, `AWSUniqueId`) as this will make make the counter
+non-distributed. For such dimensions use
+`addUniqueDimension()/addUniqueDimensions()` on the
+`SignalFxReporter.Builder` object.
 
 ### AWS Integration
 
 To enable AWS integration in SignalFx (i.e aws tag/property syncing) to a metric
-you can use `com.signalfx.metrics.aws.AWSInstanceInfo`. And either add it as a
-dimension in `MetricMetadata` or add it as a default dimension.
+you can use `com.signalfx.metrics.aws.AWSInstanceInfo`. And either add it as
+a dimension in `MetricMetadata` or add it as a default dimension.
 
 ```java
 String instanceInfo = AWSInstanceInfo.get()
@@ -315,39 +288,10 @@ Timer t = metricMetadata
 final SignalFxReporter signalfxReporter = new SignalFxReporter.Builder(
     metricRegistry,
     "SIGNALFX_AUTH_TOKEN"
-).addDimension(AWSInstanceInfo.DIMENSION_NAME, instanceInfo).build();
+).addUniqueDimension(AWSInstanceInfo.DIMENSION_NAME, instanceInfo).build();
 ```
 
-## Example Project
-
-You can find a full-stack example project called "signalfx-java-examples" in
-the repo.
-
-Run it as follows:
-
-1. Download the code and create an "auth" file in the "signalfx-java-examples"
-   directory. The auth file should contain the following:
-
-    ```
-    auth=<signalfx API Token>
-    host=https://ingest.signalfx.com
-    ```
-
-2. Run the following commands in your terminal to install and run the example
-   project, replacing `path/to/signalfx-java-examples` with the location of the
-   example project code in your environment. You must have Maven installed.
-
-    ```
-    cd path/to/signalfx-java-examples
-    mvn install
-    # an example for Yammer 2.x metrics
-    mvn exec:java -Dexec.mainClass="com.signalfx.example.YammerExample"
-    # an example for sending datapoints and events using protocol buffers
-    mvn exec:java -Dexec.mainClass="com.signalfx.example.ProtobufExample"
-    ```
-New metrics and events from the example project should appear in SignalFx.
-
-## Sending metrics without using Codahale
+### Sending metrics without using Codahale
 
 We recommend sending metrics using Codahale as shown above. You can also
 interact with our Java library directly if you do not want to use Codahale. To
@@ -403,16 +347,16 @@ try (AggregateMetricSender.Session i = mf.createSession()) {
 }
 ```
 
-## Sending metrics through a http proxy
+### Sending metrics through a HTTP proxy
 
-To send metrics through a http proxy one can set the standard java system
-properties used to control http protocol handling. There are 3 properties you
-can set to specify the proxy that will be used by the http protocol handler:
+To send metrics through a HTTP proxy one can set the standard java system
+properties used to control HTTP protocol handling. There are 3 properties you
+can set to specify the proxy that will be used by the HTTP protocol handler:
 
-* http.proxyHost: the host name of the proxy server
-* http.proxyPort: the port number, the default value being 80.
-* http.nonProxyHosts: a list of hosts that should be reached directly, bypassing
-  the proxy. This is a list of regular expressions separated by '|'. Any host
+* `http.proxyHost`: the host name of the proxy server
+* `http.proxyPort`: the port number, the default value being 80.
+* `http.nonProxyHosts`: a list of hosts that should be reached directly, bypassing
+  the proxy. This is a list of regular expressions separated by `|`. Any host
   matching one of these regular expressions will be reached through a direct
   connection instead of through a proxy.
 
@@ -427,6 +371,46 @@ Example with directive to bypass proxy for `localhost` and `host.mydomain.com`:
 ```
 $ java -Dhttp.proxyHost=webcache.mydomain.com -Dhttp.proxyPort=8080 -Dhttp.noProxyHosts=”localhost|host.mydomain.com”
 ```
+
+### Disabling compression when sending datapoints
+
+By default, the Java library compresses datapoint payloads when sending them to
+SignalFx. This can provide significant egress volume savings when sending data
+to SignalFx's ingest API. This behavior can be disabled by setting the
+`com.signalfx.public.java.disableHttpCompression` system property to `true`:
+
+```
+$ java -Dcom.signalfx.public.java.disableHttpCompression=true ...
+```
+
+## Example Project
+
+You can find a full-stack example project called "signalfx-java-examples" in
+the repo.
+
+Run it as follows:
+
+1. Download the code and create an "auth" file in the "signalfx-java-examples"
+   directory. The auth file should contain the following:
+
+    ```
+    auth=<signalfx API Token>
+    host=https://ingest.signalfx.com
+    ```
+
+2. Run the following commands in your terminal to install and run the example
+   project, replacing `path/to/signalfx-java-examples` with the location of the
+   example project code in your environment. You must have Maven installed.
+
+    ```
+    cd path/to/signalfx-java-examples
+    mvn install
+    # an example for Yammer 2.x metrics
+    mvn exec:java -Dexec.mainClass="com.signalfx.example.YammerExample"
+    # an example for sending datapoints and events using protocol buffers
+    mvn exec:java -Dexec.mainClass="com.signalfx.example.ProtobufExample"
+    ```
+New metrics and events from the example project should appear in SignalFx.
 
 ## Executing SignalFlow computations
 

--- a/signalfx-java/src/main/java/com/signalfx/metrics/SendMetrics.java
+++ b/signalfx-java/src/main/java/com/signalfx/metrics/SendMetrics.java
@@ -1,8 +1,12 @@
 package com.signalfx.metrics;
 
+import com.google.common.base.Preconditions;
+import com.signalfx.metrics.errorhandler.MetricError;
+
 import java.io.FileInputStream;
 import java.net.URL;
 import java.util.Collections;
+import java.util.Date;
 import java.util.Properties;
 
 import com.signalfx.endpoint.SignalFxEndpoint;
@@ -13,51 +17,61 @@ import com.signalfx.metrics.errorhandler.OnSendErrorHandler;
 import com.signalfx.metrics.flush.AggregateMetricSender;
 import com.signalfx.metrics.protobuf.SignalFxProtocolBuffers;
 
+/**
+ * An example application to test sending metrics with this library.
+ *
+ * @author jack
+ * @author max
+ */
 public final class SendMetrics {
-    private SendMetrics() {
-    }
+
+    private SendMetrics() {}
 
     public static void main(String[] args) throws Exception {
         Properties prop = new Properties();
         prop.load(new FileInputStream("auth.properties"));
-        final String auth_token = prop.getProperty("auth");
-        final String hostUrlStr = prop.getProperty("host");
-        final URL hostUrl = new URL(hostUrlStr);
-        System.out.println("Auth=" + auth_token + " .. host=" + hostUrl);
-        SignalFxReceiverEndpoint endpoint =
-                new SignalFxEndpoint(hostUrl.getProtocol(),
-                                      hostUrl.getHost(),
-                                      hostUrl.getPort());
-        AggregateMetricSender mf =
-                new AggregateMetricSender("test.SendMetrics",
-                                          new HttpDataPointProtobufReceiverFactory(
-                                                  endpoint)
-                                                  .setVersion(2),
-                                          new StaticAuthToken(auth_token),
-                                          Collections.<OnSendErrorHandler>emptyList());
 
-        int count = 0;
+        String token = Preconditions.checkNotNull(prop.getProperty("auth"), "No auth token set");
+        String host = Preconditions.checkNotNull(prop.getProperty("host"), "No endpoint set");
+        URL hostUrl = new URL(host);
+
+        System.out.printf("Sending metrics to %s (X-SF-Token: %s) ...%n", hostUrl, token);
+
+        SignalFxReceiverEndpoint endpoint = new SignalFxEndpoint(
+                hostUrl.getProtocol(),
+                hostUrl.getHost(),
+                hostUrl.getPort());
+
+        OnSendErrorHandler errorHandler = new OnSendErrorHandler() {
+            @Override
+            public void handleError(MetricError metricError) {
+                System.err.printf("Error %s sending data: %s%n",
+                        metricError.getMetricErrorType(),
+                        metricError.getMessage());
+                metricError.getException().printStackTrace(System.err);
+            }
+        };
+
+        AggregateMetricSender mf = new AggregateMetricSender(
+                "test.SendMetrics",
+                new HttpDataPointProtobufReceiverFactory(endpoint).setVersion(2),
+                new StaticAuthToken(token),
+                Collections.singletonList(errorHandler));
+
         while (true) {
-            System.out.println("Sending data: " + System.currentTimeMillis());
-            Thread.sleep(25);
+            Thread.sleep(250);
             AggregateMetricSender.Session i = mf.createSession();
             try {
-                count += 2;
-//                i.incrementCounter("testcounter2", 1);
-//                i.setCumulativeCounter("cumulativeCounter", count);
-//                i.setGauge("testgauge2", System.currentTimeMillis());
-                i.setDatapoint(
-                        SignalFxProtocolBuffers.DataPoint.newBuilder()
-                                .setMetric("curtime")
-                                .setValue(
-                                        SignalFxProtocolBuffers.Datum.newBuilder()
-                                                .setIntValue(System.currentTimeMillis()))
-                                .addDimensions(
-                                        SignalFxProtocolBuffers.Dimension.newBuilder()
-                                                .setKey("source")
-                                                .setValue("java"))
-                                .build());
+                i.setDatapoint(SignalFxProtocolBuffers.DataPoint.newBuilder()
+                        .setMetric("curtime")
+                        .setValue(SignalFxProtocolBuffers.Datum.newBuilder()
+                                .setIntValue(System.currentTimeMillis()))
+                        .addDimensions(
+                                SignalFxProtocolBuffers.Dimension.newBuilder()
+                                        .setKey("source")
+                                        .setValue("java")).build());
             } finally {
+                System.out.printf("Sending data at %s%n", new Date());
                 i.close();
             }
         }

--- a/signalfx-java/src/main/java/com/signalfx/metrics/connection/AbstractHttpEventProtobufReceiverConnection.java
+++ b/signalfx-java/src/main/java/com/signalfx/metrics/connection/AbstractHttpEventProtobufReceiverConnection.java
@@ -32,8 +32,10 @@ public abstract class AbstractHttpEventProtobufReceiverConnection extends Abstra
         try {
             CloseableHttpResponse resp = null;
             try {
-                resp = postToEndpoint(auth, getEntityForVersion(events),
-                        getEndpointForAddEvents());
+                resp = postToEndpoint(auth,
+                        getEntityForVersion(events),
+                        getEndpointForAddEvents(),
+                        false);
                 checkHttpResponse(resp);
             } finally {
                 if (resp != null) {

--- a/signalfx-java/src/main/java/com/signalfx/metrics/connection/HttpDataPointProtobufReceiverConnection.java
+++ b/signalfx-java/src/main/java/com/signalfx/metrics/connection/HttpDataPointProtobufReceiverConnection.java
@@ -74,7 +74,9 @@ public class HttpDataPointProtobufReceiverConnection
             CloseableHttpResponse resp = null;
             try {
                 resp = postToEndpoint(auth,
-                        new ByteArrayEntity(map_as_json, JSON_TYPE), "/v1/metric?bulkupdate=true");
+                        new ByteArrayEntity(map_as_json, JSON_TYPE),
+                        "/v1/metric?bulkupdate=true",
+                        false);
                 try {
                     body = IOUtils.toString(resp.getEntity().getContent());
                 } catch (IOException e) {

--- a/signalfx-java/src/test/java/com/signalfx/metrics/connection/HttpDataPointProtobufReceiverConnectionTest.java
+++ b/signalfx-java/src/test/java/com/signalfx/metrics/connection/HttpDataPointProtobufReceiverConnectionTest.java
@@ -5,6 +5,7 @@ package com.signalfx.metrics.connection;
 
 import java.io.IOException;
 import java.util.Collections;
+import java.util.zip.GZIPInputStream;
 
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
@@ -52,7 +53,7 @@ public class HttpDataPointProtobufReceiverConnectionTest {
             }
             SignalFxProtocolBuffers.DataPointUploadMessage all_datapoints =
                     SignalFxProtocolBuffers.DataPointUploadMessage.parseFrom(
-                            baseRequest.getInputStream());
+                            new GZIPInputStream(baseRequest.getInputStream()));
             if (!all_datapoints.getDatapoints(0).getSource().equals("source")) {
                 error("Invalid datapoint source", response, baseRequest);
                 return;


### PR DESCRIPTION
Unless the com.signalfx.public.java.disableHttpCompression property is
set to true, the signalfx-java library will now send GZip-compressed
datapoint payloads to the SignalFx ingest endpoint.