### PR TITLE
Use the STRICT_HOSTNAME_VERIFIER to validate SSL certificates' hostnames

### DIFF
--- a/signalfx-java/src/main/java/com/signalfx/metrics/connection/HttpDataPointProtobufReceiverFactory.java
+++ b/signalfx-java/src/main/java/com/signalfx/metrics/connection/HttpDataPointProtobufReceiverFactory.java
@@ -1,6 +1,14 @@
 package com.signalfx.metrics.connection;
 
+import javax.net.ssl.SSLContext;
+
+import org.apache.http.config.RegistryBuilder;
 import org.apache.http.conn.HttpClientConnectionManager;
+import org.apache.http.conn.socket.ConnectionSocketFactory;
+import org.apache.http.conn.socket.PlainConnectionSocketFactory;
+import org.apache.http.conn.ssl.SSLConnectionSocketFactory;
+import org.apache.http.conn.ssl.SSLContexts;
+import org.apache.http.conn.ssl.X509HostnameVerifier;
 import org.apache.http.impl.conn.BasicHttpClientConnectionManager;
 
 import com.signalfx.endpoint.SignalFxReceiverEndpoint;
@@ -11,13 +19,20 @@ public class HttpDataPointProtobufReceiverFactory implements DataPointReceiverFa
     public static final int DEFAULT_VERSION = 2;
 
     private final SignalFxReceiverEndpoint endpoint;
-    private HttpClientConnectionManager httpClientConnectionManager =
-            new BasicHttpClientConnectionManager();
+    private HttpClientConnectionManager httpClientConnectionManager;
     private int timeoutMs = DEFAULT_TIMEOUT_MS;
     private int version = DEFAULT_VERSION;
 
     public HttpDataPointProtobufReceiverFactory(SignalFxReceiverEndpoint endpoint) {
         this.endpoint = endpoint;
+
+        // Same as new BasicHttpClientConnectionManager() but with STRICT_HOSTNAME_VERIFIER.
+        this.httpClientConnectionManager = new BasicHttpClientConnectionManager(
+                RegistryBuilder.<ConnectionSocketFactory>create()
+                    .register("http", PlainConnectionSocketFactory.getSocketFactory())
+                    .register("https", new SSLConnectionSocketFactory(SSLContexts.createDefault(),
+                            SSLConnectionSocketFactory.STRICT_HOSTNAME_VERIFIER))
+                    .build());
     }
 
     public HttpDataPointProtobufReceiverFactory setTimeoutMs(int timeoutMs) {


### PR DESCRIPTION
The default hostname verifier isn't strict about subdomains, which we
should be for improved security.