### PR TITLE
Upgrade to Jetty 9.x

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -25,6 +25,8 @@
     <os72.protobuf-shaded.version>351</os72.protobuf-shaded.version>
     <os72.protobuf-shaded.jar-version>0.9</os72.protobuf-shaded.jar-version>
     <os72.protobuf-shaded.plugin-version>${protobuf.version}.1</os72.protobuf-shaded.plugin-version>
+    <jackson.version>2.9.7</jackson.version>
+    <jetty.version>9.2.26.v20180806</jetty.version>
   </properties>
 
   <url>http://www.signalfx.com</url>
@@ -136,24 +138,24 @@
         <groupId>junit</groupId>
         <artifactId>junit-dep</artifactId>
         <version>4.11</version>
+        <scope>test</scope>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-server</artifactId>
-        <version>8.1.15.v20140411</version>
+        <version>${jetty.version}</version>
         <scope>test</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.eclipse.jetty.websocket</groupId>
+        <artifactId>websocket-client</artifactId>
+        <version>${jetty.version}</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty.orbit</groupId>
         <artifactId>javax.servlet</artifactId>
         <version>3.0.0.v201112011016</version>
         <scope>test</scope>
-      </dependency>
-      <dependency>
-        <groupId>org.eclipse.jetty</groupId>
-        <artifactId>jetty-websocket</artifactId>
-        <version>8.1.19.v20160209</version>
-        <scope>compile</scope>
       </dependency>
       <dependency>
         <groupId>com.google.guava</groupId>
@@ -184,12 +186,12 @@
       <dependency>
         <groupId>com.fasterxml.jackson.core</groupId>
         <artifactId>jackson-databind</artifactId>
-        <version>2.2.2</version>
+        <version>${jackson.version}</version>
       </dependency>
       <dependency>
         <groupId>io.dropwizard.metrics</groupId>
         <artifactId>metrics-core</artifactId>
-        <version>3.2.3</version>
+        <version>3.2.6</version>
       </dependency>
       <dependency>
         <groupId>com.yammer.metrics</groupId>
@@ -199,12 +201,12 @@
       <dependency>
         <groupId>com.fasterxml.jackson.core</groupId>
         <artifactId>jackson-core</artifactId>
-        <version>2.2.2</version>
+        <version>${jackson.version}</version>
       </dependency>
       <dependency>
         <groupId>com.fasterxml.jackson.core</groupId>
         <artifactId>jackson-annotations</artifactId>
-        <version>2.2.2</version>
+        <version>${jackson.version}</version>
       </dependency>
       <dependency>
         <groupId>javax.validation</groupId>
@@ -219,17 +221,17 @@
       <dependency>
         <groupId>org.apache.httpcomponents</groupId>
         <artifactId>httpclient</artifactId>
-        <version>4.5.5</version>
+        <version>4.5.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.httpcomponents</groupId>
         <artifactId>httpcore</artifactId>
-        <version>4.4.9</version>
+        <version>4.4.10</version>
       </dependency>
       <dependency>
         <groupId>commons-io</groupId>
         <artifactId>commons-io</artifactId>
-        <version>2.4</version>
+        <version>2.6</version>
       </dependency>
     </dependencies>
   </dependencyManagement>
@@ -244,7 +246,7 @@
             https://maven.apache.org/plugins/maven-deploy-plugin/deploy-mojo.html
            -->
           <artifactId>maven-deploy-plugin</artifactId>
-          <version>2.8.1</version>
+          <version>2.8.2</version>
         </plugin>
       </plugins>
     </pluginManagement>
@@ -252,7 +254,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.1</version>
+        <version>3.8.0</version>
         <configuration>
           <source>1.6</source>
           <target>1.6</target>
@@ -261,7 +263,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.0.1</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -270,11 +272,14 @@
             </goals>
           </execution>
         </executions>
+        <configuration>
+          <excludePackageNames>com.signalfx.metrics.protobuf</excludePackageNames>
+        </configuration>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-source-plugin</artifactId>
-        <version>2.2.1</version>
+        <version>3.0.1</version>
         <executions>
           <execution>
             <id>attach-sources</id>
@@ -287,7 +292,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-shade-plugin</artifactId>
-        <version>3.1.0</version>
+        <version>3.2.0</version>
         <configuration>
           <createSourcesJar>true</createSourcesJar>
           <shadeSourcesContent>true</shadeSourcesContent>

--- a/signalfx-java/pom.xml
+++ b/signalfx-java/pom.xml
@@ -59,8 +59,8 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.eclipse.jetty</groupId>
-      <artifactId>jetty-websocket</artifactId>
+      <groupId>org.eclipse.jetty.websocket</groupId>
+      <artifactId>websocket-client</artifactId>
     </dependency>
     <dependency>
       <groupId>com.signalfx.public</groupId>

--- a/signalfx-java/src/main/java/com/signalfx/signalflow/SignalFlowClient.java
+++ b/signalfx-java/src/main/java/com/signalfx/signalflow/SignalFlowClient.java
@@ -29,7 +29,7 @@ public class SignalFlowClient {
      *            user api token
      */
     public SignalFlowClient(String token) {
-        this.transport = new WebSocketTransport.TransportBuilder(token).build();
+        this(new WebSocketTransport.TransportBuilder(token).build());
     }
 
     /**

--- a/signalfx-java/src/main/java/com/signalfx/signalflow/SignalFlowException.java
+++ b/signalfx-java/src/main/java/com/signalfx/signalflow/SignalFlowException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016 SignalFx, Inc. All rights reserved.
+ * Copyright (C) 2016-2018 SignalFx, Inc. All rights reserved.
  */
 package com.signalfx.signalflow;
 
@@ -14,14 +14,13 @@ public class SignalFlowException extends RuntimeException {
 
     protected int code = 0;
 
-    public SignalFlowException(int code) {
-        super("Error " + code);
+    public SignalFlowException(int code, String message) {
+        super(message);
         this.code = code;
     }
 
-    public SignalFlowException(final Integer code, String message) {
+    public SignalFlowException(String message) {
         super(message);
-        this.code = code;
     }
 
     public SignalFlowException(String message, Throwable cause) {


### PR DESCRIPTION
Upgrade various dependencies of signalfx-java, most notably switching to
Jetty 9.x for important security fixes. This involved dealing with some
important jetty-websocket framework changes for the WebSocketTransport.
Verified the changes with a local test program streaming a SignalFlow
computation.