### PR TITLE
Add timeout before SSL handshake

### DIFF
--- a/signalfx-java/src/main/java/com/signalfx/metrics/connection/HttpClientConnectionManagerFactory.java
+++ b/signalfx-java/src/main/java/com/signalfx/metrics/connection/HttpClientConnectionManagerFactory.java
@@ -1,0 +1,51 @@
+package com.signalfx.metrics.connection;
+
+import java.io.IOException;
+
+import javax.net.ssl.SSLSocket;
+
+import org.apache.http.config.RegistryBuilder;
+import org.apache.http.config.SocketConfig;
+import org.apache.http.conn.HttpClientConnectionManager;
+import org.apache.http.conn.socket.ConnectionSocketFactory;
+import org.apache.http.conn.socket.PlainConnectionSocketFactory;
+import org.apache.http.conn.ssl.SSLConnectionSocketFactory;
+import org.apache.http.impl.conn.BasicHttpClientConnectionManager;
+import org.apache.http.ssl.SSLContexts;
+
+public class HttpClientConnectionManagerFactory {
+
+  private HttpClientConnectionManagerFactory() {
+    // prevent instantiation
+  }
+
+  public static HttpClientConnectionManager withTimeoutMs(int timeoutMs) {
+    BasicHttpClientConnectionManager httpClientConnectionManager = new BasicHttpClientConnectionManager(
+        RegistryBuilder.<ConnectionSocketFactory>create()
+            .register("http", PlainConnectionSocketFactory.getSocketFactory())
+            .register("https", new SSLConnectionSocketFactoryWithTimeout(timeoutMs))
+            .build());
+
+    httpClientConnectionManager.setSocketConfig(
+        SocketConfig.custom().setSoTimeout(timeoutMs).build());
+
+    return httpClientConnectionManager;
+  }
+
+  /**
+   * Uses STRICT_HOSTNAME_VERIFIER and sets a socket timeout before attempting the SSL handshake
+   */
+  private static class SSLConnectionSocketFactoryWithTimeout extends SSLConnectionSocketFactory {
+    private final int timeoutMs;
+
+    public SSLConnectionSocketFactoryWithTimeout(int timeoutMs) {
+      super(SSLContexts.createDefault(), SSLConnectionSocketFactory.STRICT_HOSTNAME_VERIFIER);
+      this.timeoutMs = timeoutMs;
+    }
+
+    @Override
+    protected void prepareSocket(SSLSocket socket) throws IOException {
+      socket.setSoTimeout(timeoutMs);
+    }
+  }
+}


### PR DESCRIPTION
This patch attempts to mitigate a failure scenario we saw today which caused an outage of our SignalFx setup. Metrics stopped flowing to SignalFx, and when we took a thread dump of the process responsible for sending metrics to SignalFx, we saw that it was stuck inside of `sun.security.ssl.SSLSocketImpl.startHandshake`. Despite [already setting timeouts](https://github.com/signalfx/signalfx-java/blob/6c708b3285a286cd037853c90cba9e269157ac5f/signalfx-java/src/main/java/com/signalfx/connection/AbstractHttpReceiverConnection.java#L50-L52) six ways to Sunday, it appears that none of these apply to the SSL handshake. So we were getting stuck inside of the SSL handshake forever, at which point we had to kill the process to recover (until it happened again).

We've actually seen this failure scenario before and patched our internal HTTP client, so this PR just ports the mitigation we've used successfully for a while. First, it sets a `SocketConfig` with `SO_TIMEOUT` applied. Second, it uses a subclass of `SSLConnectionSocketFactory` in order to override the `prepareSocket` method and make double-sure that `SO_TIMEOUT` is set.

We've already applied this change internally and it resolved our outage.

/cc @szabowexler