### PR TITLE
Bump Jetty to latest (9.4.15.v20190215) to fix NPEs for some environs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
     <os72.protobuf-shaded.jar-version>0.9</os72.protobuf-shaded.jar-version>
     <os72.protobuf-shaded.plugin-version>${protobuf.version}.1</os72.protobuf-shaded.plugin-version>
     <jackson.version>2.9.7</jackson.version>
-    <jetty.version>9.2.26.v20180806</jetty.version>
+    <jetty.version>9.4.15.v20190215</jetty.version>
   </properties>
 
   <url>http://www.signalfx.com</url>


### PR DESCRIPTION
# Summary

Bumps Jetty to the currently released version.

# Motivation

This fixes #68 for me. If I use the version in master, I get NPEs.

# Notes

I get test failures with or without this change, so it doesn't get any worse?