### PR TITLE
Deserialize program errors correctly

### DIFF
--- a/signalfx-java/src/main/java/com/signalfx/signalflow/ChannelMessage.java
+++ b/signalfx-java/src/main/java/com/signalfx/signalflow/ChannelMessage.java
@@ -405,13 +405,26 @@ public abstract class ChannelMessage {
 
     /**
      * Message received when the computation encounters errors during its initialization.
+     * Because the error that is returned might have one of two sets of contents, this has both an
+     * `errors` and a `message` accessor. We'll be liberal here so the code can decide how to show
+     * this error later. Optimally, these should be different message types, but that's a lot of
+     * work to handle on both the backend and client side for +1/-1.
      */
     public static class ErrorMessage extends ChannelMessage {
 
+        protected int error;
         protected ArrayList<Object> errors;
+        protected String message;
 
         public ErrorMessage() {
             this.channelMessageType = Type.ERROR_MESSAGE;
+        }
+
+        /**
+         * @return The error number, akin to an HTTP error code.
+         */
+        public int getError() {
+            return this.error;
         }
 
         /**
@@ -420,6 +433,13 @@ public abstract class ChannelMessage {
          */
         public List<Object> getErrors() {
             return this.errors;
+        }
+
+        /**
+         * @return The error message for the failure
+         */
+        public String getMessage() {
+            return this.message;
         }
     }
 }

--- a/signalfx-java/src/main/java/com/signalfx/signalflow/StreamRequestException.java
+++ b/signalfx-java/src/main/java/com/signalfx/signalflow/StreamRequestException.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright (C) 2019 SignalFx, Inc. All rights reserved.
+ */
+package com.signalfx.signalflow;
+
+import java.util.List;
+
+/**
+ * Exception thrown when the computation fails at request time, possibly for syntax errors.
+ *
+ * @author cwatson
+ */
+public class StreamRequestException extends RuntimeException {
+
+    private static final long serialVersionUID = 1L;
+
+    protected int errorCode;
+    protected String message;
+
+    public StreamRequestException(int errorCode, String message) {
+        super("Computation failed (" + message + ") code: " + errorCode);
+        this.message = message;
+    }
+
+    public int getErrorCode() {
+        return this.errorCode;
+    }
+
+    public String getMessage() {
+        return this.message;
+    }
+}


### PR DESCRIPTION
# Summary

Adjust deserialization (via object mapper) of SignalFlow errors.

# Synopsis

INT-497 reports that syntax errors do not property emit an error message, instead doing a:

```
java.util.concurrent.CompletionException: com.signalfx.signalflow.ComputationFailedException: Computation failed (null)
```

This stems from the returned JSON for an error not containing an `errors` attribute. It looks like:

```
{
  "channel" : "channel-UyP2eyq8",
  "context" : {
    "column" : 154,
    "line" : 1,
    "message" : "'index' argument cannot be greater than 'total' argument",
    "programText" : "data10 = data('*', filter=filter('deployable', 'KeplerFilteredAlertsToSlackUsingRules-sfx-alert-slack-notifier') and filter('user_instance', 'false') and partition_filter(10, 5), extrapolation='null', maxExtrapolations=-1).publish(label='series10')",
    "traceback" : [ {
      "file" : "",
      "line" : 1,
      "namespace" : "<module>",
      "text" : "data10 = data('*', filter=filter('deployable', 'KeplerFilteredAlertsToSlackUsingRules-sfx-alert-slack-notifier') and filter('user_instance', 'false') and partition_filter(10, 5), extrapolation='null', maxExtrapolations=-1).publish(label='series10')"
    } ]
  },
  "error" : 400,
  "errorType" : "ANALYTICS_PROGRAM_TYPE_ERROR",
  "message" : "Error executing SignalFlow program (ref: D0BUgZxAYAA): [File \"\", line 1, in \ndata10 = data('*', filter=filter('deployable', 'KeplerFilteredAlertsToSlackUsingRules-sfx-alert-slack-notifier') and filter('user_instance', 'false') and partition_filter(10, 5), extrapolation='null', maxExtrapolations=-1).publish(label='series10')\nTypeError: 'index' argument cannot be greater than 'total' argument]",
  "type" : "error"
}
```

The context here seems interesting, but the important bit is the message. To that end I changed the `ComputationFailedException` to have a single `String message` instead of an `ArrayList<Object>`. 

# Notes

It's not clear to me if the existing code is correct in some *other* case, and this is an exception. (No pun intended.) I can't find any documentation [here](https://developers.signalfx.com/signalflow_analytics/rest_api_messages/signalflow_messages_overview.html) that explains the contents of these error messages to validate my work.  Instead, I'm using a test case that includes a syntax error (seen above) to exercise this.