### PR TITLE
Fix up backfillDataPoints call to match API

### DIFF
--- a/signalfx-java/src/main/java/com/signalfx/metrics/connection/AbstractHttpDataPointProtobufReceiverConnection.java
+++ b/signalfx-java/src/main/java/com/signalfx/metrics/connection/AbstractHttpDataPointProtobufReceiverConnection.java
@@ -1,14 +1,20 @@
 package com.signalfx.metrics.connection;
 
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.util.List;
+import java.util.Map;
 
+import com.google.common.collect.Lists;
 import org.apache.http.HttpEntity;
 import org.apache.http.HttpStatus;
+import org.apache.http.NameValuePair;
 import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.utils.URLEncodedUtils;
 import org.apache.http.conn.HttpClientConnectionManager;
 import org.apache.http.entity.ContentType;
 import org.apache.http.entity.InputStreamEntity;
+import org.apache.http.message.BasicNameValuePair;
 
 import com.signalfx.common.proto.ProtocolBufferStreamingInputStream;
 import com.signalfx.connection.AbstractHttpReceiverConnection;
@@ -63,20 +69,31 @@ public abstract class AbstractHttpDataPointProtobufReceiverConnection extends Ab
             List<SignalFxProtocolBuffers.DataPoint> dataPoints);
 
     @Override
-    public void backfillDataPoints(String auth, String source, String metric,
-                                   List<SignalFxProtocolBuffers.Datum> datumPoints)
+    public void backfillDataPoints(String auth, String metric, String metricType, String orgId, Map<String,String> dimensions,
+                                   List<SignalFxProtocolBuffers.PointValue> datumPoints)
             throws SignalFxMetricsException {
         if (datumPoints.isEmpty()) {
             return;
         }
+
+        List<NameValuePair> params = Lists.newArrayList();
+        params.add(new BasicNameValuePair("orgid", orgId));
+        params.add(new BasicNameValuePair("metric_type", metricType));
+        params.add(new BasicNameValuePair("metric", metric));
+
+        // Each dimension is added as a param in the form of "sfxdim_DIMNAME"
+        for (Map.Entry<String,String> entry : dimensions.entrySet()) {
+            params.add(new BasicNameValuePair("sfxdim_" + entry.getKey(), entry.getValue()));
+        }
+
         try {
             CloseableHttpResponse resp = null;
             try {
                 resp = postToEndpoint(auth,
                         new InputStreamEntity(
-                                new ProtocolBufferStreamingInputStream<SignalFxProtocolBuffers.Datum>(
+                                new ProtocolBufferStreamingInputStream<SignalFxProtocolBuffers.PointValue>(
                                         datumPoints.iterator()), PROTO_TYPE),
-                        "/v1/backfill",
+                        "/v1/backfill?" + URLEncodedUtils.format(params, StandardCharsets.UTF_8),
                         false);
 
                 int code = resp.getStatusLine().getStatusCode();
@@ -89,7 +106,7 @@ public abstract class AbstractHttpDataPointProtobufReceiverConnection extends Ab
                 }
             }
         } catch (IOException e) {
-            throw new SignalFxMetricsException("Exception posting to addDataPoints", e);
+            throw new SignalFxMetricsException("Exception posting to backfillDataPoints", e);
         }
     }
 }

--- a/signalfx-java/src/main/java/com/signalfx/metrics/connection/DataPointReceiver.java
+++ b/signalfx-java/src/main/java/com/signalfx/metrics/connection/DataPointReceiver.java
@@ -10,8 +10,8 @@ public interface DataPointReceiver {
     void addDataPoints(String auth, List<SignalFxProtocolBuffers.DataPoint> dataPoints)
             throws SignalFxMetricsException;
 
-    void backfillDataPoints(String auth, String source, String metric,
-                            List<SignalFxProtocolBuffers.Datum> datumPoints)
+    void backfillDataPoints(String auth, String metric, String metricType, String orgId, Map<String,String> dimensions,
+                            List<SignalFxProtocolBuffers.PointValue> datumPoints)
             throws SignalFxMetricsException;
 
     Map<String, Boolean> registerMetrics(String auth, Map<String, SignalFxProtocolBuffers.MetricType> metricTypes)

--- a/signalfx-java/src/main/java/com/signalfx/metrics/connection/StoredDataPointReceiver.java
+++ b/signalfx-java/src/main/java/com/signalfx/metrics/connection/StoredDataPointReceiver.java
@@ -64,8 +64,8 @@ public class StoredDataPointReceiver implements DataPointReceiver {
     }
 
     @Override
-    public void backfillDataPoints(String auth, String source, String metric,
-                                   List<SignalFxProtocolBuffers.Datum> datumPoints)
+    public void backfillDataPoints(String auth, String metric, String metricType, String orgId, Map<String,String> dimensions,
+                                   List<SignalFxProtocolBuffers.PointValue> datumPoints)
             throws SignalFxMetricsException {}
 
     @Override


### PR DESCRIPTION
# Summary

Update the `backfillDataPoints` call to match the current [API specification](https://developers.signalfx.com/backfill_reference.html) as the current one is old and hasn't been updated.

# Motivation

INT-604 surfaced that the Java client's backfill support wasn't correct, so this fixes it up!

# Notes

I added a test to validate everything except the payload. Since it's protobuf I don't feel too inclined to worry about that bit.

cc @almightyoatmeal