### PR TITLE
Fix code example in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,11 +114,13 @@ the following ways:
 // Load string from properties file, env, manually, etc...
 final String ingestStr = "https://ingest.{REALM}.signalfx.com";
 final URL ingestUrl = new URL(ingestStr);
-SignalFxReceiverEndpoint endpoint = new SignalFxEndpoint(ingestUrl.getProtocol(),
-    ingestUrl.getHost(), ingestUrl.getPort());
-MetricsRegistry metricsRegistry = new MetricsRegistry();
-SignalFxReporter reporter = new SignalFxReporter.Builder(metricsRegistry,
-    new StaticAuthToken(ORG_TOKEN), ingestStr).setEndpoint(endpoint);
+SignalFxReceiverEndpoint endpoint = 
+    new SignalFxEndpoint(ingestUrl.getProtocol(), ingestUrl.getHost(), ingestUrl.getPort());
+MetricRegistry metricRegistry = new MetricRegistry();
+SignalFxReporter reporter = 
+    new SignalFxReporter.Builder(metricRegistry, new StaticAuthToken(ORG_TOKEN), ingestStr)
+        .setEndpoint(endpoint)
+        .build();
 ```
 
 ### Codahale Metrics 3.0.x


### PR DESCRIPTION
The example code doesn't compile. I made two changes:
* finished the builder
* Use MetricRegistry of the codahale metrics library (I think the current code still refers to yammer, since it's Metric*s*Registry)