### PR TITLE
Update Jetty version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
     <os72.protobuf-shaded.plugin-version>${protobuf.version}.1</os72.protobuf-shaded.plugin-version>
     <jackson.version>2.9.9</jackson.version>
     <jackson.databind.version>2.9.9.3</jackson.databind.version>
-    <jetty.version>9.2.26.v20180806</jetty.version>
+    <jetty.version>9.2.28.v20190418</jetty.version>
   </properties>
 
   <url>http://www.signalfx.com</url>


### PR DESCRIPTION
During build, `maven-shade-plugin` copies a number of classes from `jetty` to the resulting jar file. The classes are available in `com.signalfx.shaded.jetty` package. Unfortunately, `signalfx-java` uses an old version of `jetty` which is affected by several vulnerabilities:

- CVE-2017-7658
- CVE-2017-9735
- CVE-2019-10241
- CVE-2019-10246

I have verified that the vulnerable classes are included to the resulting jar, and can be accessed by an application if only `signalfx-java` is added as a dependency (`jetty` doesn't have to added explicitly). 

Strictly speaking, it seems to be extremely difficult to exploit the issues above if an application just uses `signalfx-java`. I am not putting all the details here, but please let me know if you are interested. However, it might be better to update jetty to be on the safe side. Furthermore, dependency scanners like [Vulas](https://github.com/SAP/vulnerability-assessment-tool) report the issues above if `signalfx-java` is used by an application. Updating `jetty` version may make user's life a bit easier.

The patch updates `jetty` to the latest version in the `9.x` branch.

I am also wondering if it is necessary to relocate jetty classes with `maven-shade-plugin`. I am not an expert in `signalfx-java` but I see that `jetty-server` is added as a test dependency. Looks like it's used only for testing but not required by applications which use `signalfx-java`.

Please let me know if `jetty` may be removed from the configuration of `maven-shade-plugin`.