### PR TITLE
Bug fix for sending metric with connection pool

### DIFF
--- a/signalfx-java/src/main/java/com/signalfx/metrics/connection/AbstractHttpDataPointProtobufReceiverConnection.java
+++ b/signalfx-java/src/main/java/com/signalfx/metrics/connection/AbstractHttpDataPointProtobufReceiverConnection.java
@@ -55,6 +55,10 @@ public abstract class AbstractHttpDataPointProtobufReceiverConnection extends Ab
                 }
             } finally {
                 if (resp != null) {
+                    HttpEntity entity = resp.getEntity();
+                    if (entity != null) {
+                        entity.getContent().close();
+                    }
                     resp.close();
                 }
             }
@@ -102,6 +106,10 @@ public abstract class AbstractHttpDataPointProtobufReceiverConnection extends Ab
                 }
             } finally {
                 if (resp != null) {
+                    HttpEntity entity = resp.getEntity();
+                    if (entity != null) {
+                        entity.getContent().close();
+                    }
                     resp.close();
                 }
             }


### PR DESCRIPTION
For the case when using `PoolingHttpClientConnectionManager`, e.g.
```java
SignalFxReceiverEndpoint endpoint =
      new SignalFxEndpoint(ingestUrl.getProtocol(), ingestUrl.getHost(), ingestUrl.getPort());

PoolingHttpClientConnectionManager m = new PoolingHttpClientConnectionManager(); 
HttpDataPointProtobufReceiverFactory f = new HttpDataPointProtobufReceiverFactory(endpoint).setVersion(2);
f.setHttpClientConnectionManager(m); // We pass a HTTP connection pool here (the default connection pool for apache http components) in order to support HTTP keep-alive

AggregateMetricSender mf = new AggregateMetricSender("SendMetrics",
      f,
      new HttpEventProtobufReceiverFactory(endpoint),
      new StaticAuthToken("<Org Token>"),
      Collections.<OnSendErrorHandler>singleton(new OnSendErrorHandler() {
        @Override
        public void handleError(MetricError metricError) {
          System.out.println("Unable to POST metrics to SignalFx: " + metricError.getMessage() + " with errorType:" + metricError.getMetricErrorType());
        }
      }));
     

for (true) {
    // dp = get a batch of metric data somewhere
    AggregateMetricSender.Session session = mf.createSession();
    session.setDatapoint(dp);
    try {
        session.close();
    } catch (IOException ex) {
        System.out.println("Problem closing AggregateMetricSender.Session object");
        throw ex;
    }
}
```
Calling `resp.close()` directly will terminate the reuse-able TCP connection, while calling `resp.getEntity().getContent().close()` before it will release the TCP connection back to pool and reuse it in the future (for HTTP keep-alive) (Probably a bug for apache HTTP components)

Network packets screenshoots (captured by Wireshark) for sending 3 batches of metrics by above sample follow:

Before this MR, we can observe 3 TCP connections, each of which sends one batch of metric
<img width="1666" alt="sfx_metric_1" src="https://user-images.githubusercontent.com/2720324/87131891-ef374780-c249-11ea-9242-b55fc4a491b5.png">
<img width="1679" alt="sfx_metric_2" src="https://user-images.githubusercontent.com/2720324/87131902-f52d2880-c249-11ea-8091-b5a99a9e6e37.png">
<img width="1680" alt="sfx_metric_3" src="https://user-images.githubusercontent.com/2720324/87131915-f9f1dc80-c249-11ea-85da-cdc385a1f58d.png">

After this MR, we can observe 1 TCP connection, which sends 3 batches of metric
<img width="1620" alt="after_fix" src="https://user-images.githubusercontent.com/2720324/87132029-2279d680-c24a-11ea-8bcc-0e00b0788ae9.png">

Feel free to ping @ xwu in Splunk's slack workspace if there are any question, thanks!