### PR TITLE
Update httpclient.version to 4.5.13 to address CVE-2020-13956

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -221,7 +221,7 @@
       <dependency>
         <groupId>org.apache.httpcomponents</groupId>
         <artifactId>httpclient</artifactId>
-        <version>4.5.6</version>
+        <version>4.5.13</version>
       </dependency>
       <dependency>
         <groupId>org.apache.httpcomponents</groupId>


### PR DESCRIPTION
As per https://bugzilla.redhat.com/show_bug.cgi?id=1886587, http.client libraries below version 4.5.13 have the vulnerability [CVE-2020-13956](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-13956). 

As signalfx-java rebundles http.client (4.5.6) classes as seen at https://github.com/signalfx/signalfx-java/blob/master/pom.xml#L294. This makes it vulnerable and hence our security scans are detecting it as a vulnerable library. Hence updating the httpclient.version to 4.5.13.