### PR TITLE
bump commons-io version from 2.6 to 2.7 (mitigate CVE-2021-29425)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -230,7 +230,7 @@
       <dependency>
         <groupId>commons-io</groupId>
         <artifactId>commons-io</artifactId>
-        <version>2.6</version>
+        <version>2.7</version>
       </dependency>
     </dependencies>
   </dependencyManagement>


### PR DESCRIPTION
Dependabot flagged this, so let's bump the version.