### PR TITLE
Use pooling connection manager by default to be able to detect connections closed by the server

### DIFF
--- a/signalfx-java/src/main/java/com/signalfx/metrics/connection/AbstractHttpDataPointProtobufReceiverConnection.java
+++ b/signalfx-java/src/main/java/com/signalfx/metrics/connection/AbstractHttpDataPointProtobufReceiverConnection.java
@@ -21,6 +21,7 @@ import com.signalfx.connection.AbstractHttpReceiverConnection;
 import com.signalfx.endpoint.SignalFxReceiverEndpoint;
 import com.signalfx.metrics.SignalFxMetricsException;
 import com.signalfx.metrics.protobuf.SignalFxProtocolBuffers;
+import org.apache.http.util.EntityUtils;
 
 public abstract class AbstractHttpDataPointProtobufReceiverConnection extends AbstractHttpReceiverConnection implements DataPointReceiver {
 
@@ -56,11 +57,12 @@ public abstract class AbstractHttpDataPointProtobufReceiverConnection extends Ab
                 }
             } finally {
                 if (resp != null) {
-                    HttpEntity entity = resp.getEntity();
-                    if (entity != null) {
-                        entity.getContent().close();
+                    try {
+                        HttpEntity entity = resp.getEntity();
+                        EntityUtils.consume(entity);
+                    } finally {
+                        resp.close();
                     }
-                    resp.close();
                 }
             }
         } catch (IOException e) {

--- a/signalfx-java/src/main/java/com/signalfx/metrics/connection/HttpClientConnectionManagerFactory.java
+++ b/signalfx-java/src/main/java/com/signalfx/metrics/connection/HttpClientConnectionManagerFactory.java
@@ -10,7 +10,7 @@ import org.apache.http.conn.HttpClientConnectionManager;
 import org.apache.http.conn.socket.ConnectionSocketFactory;
 import org.apache.http.conn.socket.PlainConnectionSocketFactory;
 import org.apache.http.conn.ssl.SSLConnectionSocketFactory;
-import org.apache.http.impl.conn.BasicHttpClientConnectionManager;
+import org.apache.http.impl.conn.PoolingHttpClientConnectionManager;
 import org.apache.http.ssl.SSLContexts;
 
 public class HttpClientConnectionManagerFactory {
@@ -20,13 +20,13 @@ public class HttpClientConnectionManagerFactory {
   }
 
   public static HttpClientConnectionManager withTimeoutMs(int timeoutMs) {
-    BasicHttpClientConnectionManager httpClientConnectionManager = new BasicHttpClientConnectionManager(
+    PoolingHttpClientConnectionManager httpClientConnectionManager = new PoolingHttpClientConnectionManager(
         RegistryBuilder.<ConnectionSocketFactory>create()
             .register("http", PlainConnectionSocketFactory.getSocketFactory())
             .register("https", new SSLConnectionSocketFactoryWithTimeout(timeoutMs))
             .build());
 
-    httpClientConnectionManager.setSocketConfig(
+    httpClientConnectionManager.setDefaultSocketConfig(
         SocketConfig.custom().setSoTimeout(timeoutMs).build());
 
     return httpClientConnectionManager;

--- a/signalfx-java/src/test/java/com/signalfx/metrics/connection/HttpDataPointProtobufReceiverConnectionTest.java
+++ b/signalfx-java/src/test/java/com/signalfx/metrics/connection/HttpDataPointProtobufReceiverConnectionTest.java
@@ -3,6 +3,9 @@
  */
 package com.signalfx.metrics.connection;
 
+import com.signalfx.connection.AbstractHttpReceiverConnection;
+import com.signalfx.endpoint.SignalFxEndpoint;
+import com.signalfx.metrics.protobuf.SignalFxProtocolBuffers;
 import java.io.IOException;
 import java.net.URI;
 import java.nio.charset.StandardCharsets;
@@ -12,197 +15,221 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.zip.GZIPInputStream;
-
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
-
 import org.apache.http.HttpStatus;
 import org.apache.http.NameValuePair;
 import org.apache.http.client.utils.URLEncodedUtils;
 import org.apache.http.message.BasicNameValuePair;
+import org.eclipse.jetty.server.Connector;
 import org.eclipse.jetty.server.Request;
 import org.eclipse.jetty.server.Server;
+import org.eclipse.jetty.server.ServerConnector;
 import org.eclipse.jetty.server.handler.AbstractHandler;
 import org.junit.Test;
 
-import com.signalfx.connection.AbstractHttpReceiverConnection;
-import com.signalfx.endpoint.SignalFxEndpoint;
-import com.signalfx.metrics.protobuf.SignalFxProtocolBuffers;
-
 public class HttpDataPointProtobufReceiverConnectionTest {
 
-    public static final String AUTH_TOKEN = "AUTH_TOKEN";
+  public static final String AUTH_TOKEN = "AUTH_TOKEN";
 
-    @Test
-    public void testHttpConnection() throws Exception {
-        Server server = new Server(0);
-        server.setHandler(new AddPointsHandler());
-        server.start();
-        URI uri = server.getURI();
-        DataPointReceiver dpr = new HttpDataPointProtobufReceiverFactory(
-                new SignalFxEndpoint(uri.getScheme(), uri.getHost(), uri.getPort()))
-                .createDataPointReceiver();
-        dpr.addDataPoints(AUTH_TOKEN, Collections.singletonList(
-                SignalFxProtocolBuffers.DataPoint.newBuilder().setSource("source").build()));
-        server.stop();
+  @Test
+  public void testHttpConnection() throws Exception {
+    Server server = new Server(0);
+    server.setHandler(new AddPointsHandler());
+    server.start();
+    URI uri = server.getURI();
+    DataPointReceiver dpr = new HttpDataPointProtobufReceiverFactory(
+        new SignalFxEndpoint(uri.getScheme(), uri.getHost(), uri.getPort()))
+        .createDataPointReceiver();
+
+    dpr.addDataPoints(AUTH_TOKEN, Collections.singletonList(
+        SignalFxProtocolBuffers.DataPoint.newBuilder().setSource("source").build()));
+    server.stop();
+  }
+
+  @Test
+  public void shouldSendDataEvenIfServerClosedConnection() throws Exception {
+    int serverIdleTimeout = 5000;
+
+    Server server = new Server();
+    ServerConnector connector = new ServerConnector(server);
+    connector.setIdleTimeout(serverIdleTimeout);
+    connector.setPort(0);
+    server.setConnectors(new Connector[]{connector});
+    server.setHandler(new AddPointsHandler());
+    server.start();
+
+    URI uri = server.getURI();
+    DataPointReceiver dpr = new HttpDataPointProtobufReceiverFactory(
+        new SignalFxEndpoint(uri.getScheme(), uri.getHost(), uri.getPort()))
+        .createDataPointReceiver();
+
+    dpr.addDataPoints(AUTH_TOKEN, Collections.singletonList(
+        SignalFxProtocolBuffers.DataPoint.newBuilder().setSource("source").build()));
+
+    Thread.sleep(serverIdleTimeout + 1000);
+
+    dpr.addDataPoints(AUTH_TOKEN, Collections.singletonList(
+        SignalFxProtocolBuffers.DataPoint.newBuilder().setSource("source").build()));
+    server.stop();
+  }
+
+  @Test
+  public void testBackfill() throws Exception {
+    Server server = new Server(0);
+    server.setHandler(new BackfillHandler());
+    server.start();
+    URI uri = server.getURI();
+    DataPointReceiver dpr = new HttpDataPointProtobufReceiverFactory(
+        new SignalFxEndpoint(uri.getScheme(), uri.getHost(), uri.getPort()))
+        .createDataPointReceiver();
+
+    ArrayList<SignalFxProtocolBuffers.PointValue> values = new ArrayList<SignalFxProtocolBuffers.PointValue>(Arrays.asList(
+        SignalFxProtocolBuffers.PointValue.newBuilder().setTimestamp(System.currentTimeMillis())
+            .setValue(SignalFxProtocolBuffers.Datum.newBuilder().setDoubleValue(123.0)).build()
+    ));
+    HashMap<String, String> dims = new HashMap<String, String>();
+    dims.put("baz", "gorch");
+    dims.put("moo", "cow");
+
+    dpr.backfillDataPoints(AUTH_TOKEN, "foo.bar.baz", "counter", "ABC123", dims, values);
+    server.stop();
+  }
+
+  private class AddPointsHandler extends AbstractHandler {
+    @Override
+    public void handle(String target, Request baseRequest, HttpServletRequest request,
+                       HttpServletResponse response) throws IOException, ServletException {
+      if (!request.getHeader("X-SF-TOKEN").equals(AUTH_TOKEN)) {
+        error("Invalid auth token", response, baseRequest);
+        return;
+      }
+      if (!request.getHeader("User-Agent")
+          .equals(AbstractHttpReceiverConnection.USER_AGENT)) {
+        error("Invalid User agent: " + request.getHeader("User-Agent") + " vs "
+              + AbstractHttpReceiverConnection.USER_AGENT, response, baseRequest);
+        return;
+      }
+      SignalFxProtocolBuffers.DataPointUploadMessage all_datapoints =
+          SignalFxProtocolBuffers.DataPointUploadMessage.parseFrom(
+              new GZIPInputStream(baseRequest.getInputStream()));
+      if (!all_datapoints.getDatapoints(0).getSource().equals("source")) {
+        error("Invalid datapoint source", response, baseRequest);
+        return;
+      }
+      response.setStatus(HttpStatus.SC_OK);
+      response.getWriter().write("\"OK\"");
+      baseRequest.setHandled(true);
     }
 
-    @Test
-    public void testBackfill() throws Exception {
-        Server server = new Server(0);
-        server.setHandler(new BackfillHandler());
-        server.start();
-        URI uri = server.getURI();
-        DataPointReceiver dpr = new HttpDataPointProtobufReceiverFactory(
-                new SignalFxEndpoint(uri.getScheme(), uri.getHost(), uri.getPort()))
-                .createDataPointReceiver();
-
-        ArrayList<SignalFxProtocolBuffers.PointValue> values = new ArrayList<SignalFxProtocolBuffers.PointValue>(Arrays.asList(
-                SignalFxProtocolBuffers.PointValue.newBuilder().setTimestamp(System.currentTimeMillis())
-                        .setValue(SignalFxProtocolBuffers.Datum.newBuilder().setDoubleValue(123.0)).build()
-        ));
-        HashMap<String,String> dims = new HashMap<String,String>();
-        dims.put("baz", "gorch");
-        dims.put("moo", "cow");
-
-        dpr.backfillDataPoints(AUTH_TOKEN, "foo.bar.baz", "counter", "ABC123", dims, values);
-        server.stop();
+    private void error(String message, HttpServletResponse response, Request baseRequest)
+        throws IOException {
+      response.setStatus(HttpStatus.SC_BAD_REQUEST);
+      response.getWriter().write(message);
+      baseRequest.setHandled(true);
     }
 
-    private class AddPointsHandler extends AbstractHandler {
-        @Override
-        public void handle(String target, Request baseRequest, HttpServletRequest request,
-                           HttpServletResponse response) throws IOException, ServletException {
-            if (!request.getHeader("X-SF-TOKEN").equals(AUTH_TOKEN)) {
-                error("Invalid auth token", response, baseRequest);
-                return;
-            }
-            if (!request.getHeader("User-Agent")
-                    .equals(AbstractHttpReceiverConnection.USER_AGENT)) {
-                error("Invalid User agent: " + request.getHeader("User-Agent") + " vs "
-                        + AbstractHttpReceiverConnection.USER_AGENT, response, baseRequest);
-                return;
-            }
-            SignalFxProtocolBuffers.DataPointUploadMessage all_datapoints =
-                    SignalFxProtocolBuffers.DataPointUploadMessage.parseFrom(
-                            new GZIPInputStream(baseRequest.getInputStream()));
-            if (!all_datapoints.getDatapoints(0).getSource().equals("source")) {
-                error("Invalid datapoint source", response, baseRequest);
-                return;
-            }
-            response.setStatus(HttpStatus.SC_OK);
-            response.getWriter().write("\"OK\"");
-            baseRequest.setHandled(true);
-        }
-
-        private void error(String message, HttpServletResponse response, Request baseRequest)
-                throws IOException {
-            response.setStatus(HttpStatus.SC_BAD_REQUEST);
-            response.getWriter().write(message);
-            baseRequest.setHandled(true);
-        }
-
-        @Override
-        public boolean isRunning() {
-            return false;
-        }
-
-        @Override
-        public boolean isStarted() {
-            return false;
-        }
-
-        @Override
-        public boolean isStarting() {
-            return false;
-        }
-
-        @Override
-        public boolean isStopping() {
-            return false;
-        }
-
-        @Override
-        public boolean isStopped() {
-            return false;
-        }
-
-        @Override
-        public boolean isFailed() {
-            return false;
-        }
+    @Override
+    public boolean isRunning() {
+      return false;
     }
 
-    private class BackfillHandler extends AbstractHandler {
-        @Override
-        public void handle(String target, Request baseRequest, HttpServletRequest request,
-                           HttpServletResponse response) throws IOException, ServletException {
-            if(!request.getMethod().equals("POST")) {
-                error("Incorrect HTTP method for backfill", response, baseRequest);
-                return;
-            }
-            if(!request.getRequestURL().toString().endsWith("/v1/backfill")) {
-                error("Incorrect URL for backfill", response, baseRequest);
-            }
-
-            List<NameValuePair> params = URLEncodedUtils.parse(baseRequest.getQueryString(), StandardCharsets.UTF_8);
-            if(!params.contains(new BasicNameValuePair("orgid", "ABC123"))) {
-                error("orgid param is missing for backfill", response, baseRequest);
-            }
-            if(!params.contains(new BasicNameValuePair("metric_type", "counter"))) {
-                error("metric_type is missing for backfill", response, baseRequest);
-            }
-            if(!params.contains(new BasicNameValuePair("metric", "foo.bar.baz"))) {
-                error("metric is missing for backfill", response, baseRequest);
-            }
-            if(!params.contains(new BasicNameValuePair("sfdim_baz", "gorch"))) {
-                error("metric is missing for backfill", response, baseRequest);
-            }
-            if(!params.contains(new BasicNameValuePair("sfdim_moo", "cow"))) {
-                error("metric is missing for backfill", response, baseRequest);
-            }
-
-            response.setStatus(HttpStatus.SC_OK);
-            response.getWriter().write("\"OK\"");
-            baseRequest.setHandled(true);
-        }
-
-        private void error(String message, HttpServletResponse response, Request baseRequest)
-                throws IOException {
-            response.setStatus(HttpStatus.SC_BAD_REQUEST);
-            response.getWriter().write(message);
-            baseRequest.setHandled(true);
-        }
-
-        @Override
-        public boolean isRunning() {
-            return false;
-        }
-
-        @Override
-        public boolean isStarted() {
-            return false;
-        }
-
-        @Override
-        public boolean isStarting() {
-            return false;
-        }
-
-        @Override
-        public boolean isStopping() {
-            return false;
-        }
-
-        @Override
-        public boolean isStopped() {
-            return false;
-        }
-
-        @Override
-        public boolean isFailed() {
-            return false;
-        }
+    @Override
+    public boolean isStarted() {
+      return false;
     }
+
+    @Override
+    public boolean isStarting() {
+      return false;
+    }
+
+    @Override
+    public boolean isStopping() {
+      return false;
+    }
+
+    @Override
+    public boolean isStopped() {
+      return false;
+    }
+
+    @Override
+    public boolean isFailed() {
+      return false;
+    }
+  }
+
+  private class BackfillHandler extends AbstractHandler {
+    @Override
+    public void handle(String target, Request baseRequest, HttpServletRequest request,
+                       HttpServletResponse response) throws IOException, ServletException {
+      if (!request.getMethod().equals("POST")) {
+        error("Incorrect HTTP method for backfill", response, baseRequest);
+        return;
+      }
+      if (!request.getRequestURL().toString().endsWith("/v1/backfill")) {
+        error("Incorrect URL for backfill", response, baseRequest);
+      }
+
+      List<NameValuePair> params = URLEncodedUtils.parse(baseRequest.getQueryString(), StandardCharsets.UTF_8);
+      if (!params.contains(new BasicNameValuePair("orgid", "ABC123"))) {
+        error("orgid param is missing for backfill", response, baseRequest);
+      }
+      if (!params.contains(new BasicNameValuePair("metric_type", "counter"))) {
+        error("metric_type is missing for backfill", response, baseRequest);
+      }
+      if (!params.contains(new BasicNameValuePair("metric", "foo.bar.baz"))) {
+        error("metric is missing for backfill", response, baseRequest);
+      }
+      if (!params.contains(new BasicNameValuePair("sfdim_baz", "gorch"))) {
+        error("metric is missing for backfill", response, baseRequest);
+      }
+      if (!params.contains(new BasicNameValuePair("sfdim_moo", "cow"))) {
+        error("metric is missing for backfill", response, baseRequest);
+      }
+
+      response.setStatus(HttpStatus.SC_OK);
+      response.getWriter().write("\"OK\"");
+      baseRequest.setHandled(true);
+    }
+
+    private void error(String message, HttpServletResponse response, Request baseRequest)
+        throws IOException {
+      response.setStatus(HttpStatus.SC_BAD_REQUEST);
+      response.getWriter().write(message);
+      baseRequest.setHandled(true);
+    }
+
+    @Override
+    public boolean isRunning() {
+      return false;
+    }
+
+    @Override
+    public boolean isStarted() {
+      return false;
+    }
+
+    @Override
+    public boolean isStarting() {
+      return false;
+    }
+
+    @Override
+    public boolean isStopping() {
+      return false;
+    }
+
+    @Override
+    public boolean isStopped() {
+      return false;
+    }
+
+    @Override
+    public boolean isFailed() {
+      return false;
+    }
+  }
 }


### PR DESCRIPTION
Fixes #112

Before the #91 we always closed http connection after each request. In order to better support pooling connection #91 replaced that with proper releasing connection instead of just closing it. This works well with pooling connection managers. But by default this library used single connection and after that PR it tried to reuse that single connection always. The problem is that server can close this connection from its side. Pooling connection manager properly checks connection for expiration after 2s of disuse. Single connection manager does not do.

This PR switches to using `PoolingHttpClientConnectionManager` by default which checks stale connections before use.