### PR TITLE
Using Zulu builds of OpenJDK in GH actions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -22,7 +22,7 @@ jobs:
       - name: Set up JDK ${{ matrix.java-version }}
         uses: actions/setup-java@v2
         with:
-          distribution: zulu
+          distribution: temurin
           java-version: ${{ matrix.java-version }}
 
       - name: Build

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        java-version: [ 8.0.292+10, 11.0.11+9 ]
+        java-version: [ 8.0.292+10, 11.0.11+9, 17-ea ]
       fail-fast: false
     steps:
       - uses: actions/checkout@v2.3.4
@@ -22,7 +22,7 @@ jobs:
       - name: Set up JDK ${{ matrix.java-version }}
         uses: actions/setup-java@v2
         with:
-          distribution: adopt
+          distribution: zulu
           java-version: ${{ matrix.java-version }}
 
       - name: Build

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        java-version: [ 8.0.292+10, 11.0.11+9 ]
+        java-version: [ 8.0.292+10, 11.0.11+9, 17-ea ]
       fail-fast: false
     steps:
       - uses: actions/checkout@v2.3.4
@@ -25,7 +25,7 @@ jobs:
       - name: Set up JDK ${{ matrix.java-version }}
         uses: actions/setup-java@v2
         with:
-          distribution: adopt
+          distribution: zulu
           java-version: ${{ matrix.java-version }}
 
       - name: Build


### PR DESCRIPTION
The AdoptOpenJDK has been discontinued Since July 2021. When using Zulu you get all the latest updated builds for all versions of OpenJDK. Also added the latest JDK 17 LTS release. 