### PR TITLE
Exclude google *.proto files

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -294,6 +294,14 @@
         <configuration>
           <createSourcesJar>true</createSourcesJar>
           <shadeSourcesContent>true</shadeSourcesContent>
+          <filters>
+            <filter>
+              <artifact>*:*</artifact>
+              <excludes>
+                <exclude>google/protobuf/**/*.proto</exclude>
+              </excludes>
+            </filter>
+          </filters>
           <artifactSet>
             <excludes>
               <exclude>org.slf4j:*</exclude>


### PR DESCRIPTION
They lead to conflicts and cause problems for protobuf-maven-plugin.