### PR TITLE
Exclude additional files from the release process

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -298,7 +298,9 @@
             <filter>
               <artifact>*:*</artifact>
               <excludes>
+                <exclude>about.html</exclude>
                 <exclude>google/protobuf/**/*.proto</exclude>
+                <exclude>mozilla/*.txt</exclude>
               </excludes>
             </filter>
           </filters>
@@ -367,6 +369,5 @@
     <module>signalfx-commons-protoc-java</module>
     <module>signalfx-codahale</module>
     <module>signalfx-yammer</module>
-    <module>micrometer-registry-signalfx</module>
   </modules>
 </project>


### PR DESCRIPTION
Fixes #189

I've also excluded the whole `micrometer-registry-signalfx` module from the release -- that was supposed to be a one-time thing after all. (I haven't removed the code though, "just in case"...)