### PR TITLE
Force apache commons-codec to 1.15

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -156,6 +156,12 @@
         <version>2.11.0</version>
       </dependency>
       <dependency>
+        <!-- Temp work-around until httpclient upgrades its codec version -->
+        <groupId>commons-codec</groupId>
+        <artifactId>commons-codec</artifactId>
+        <version>1.15</version>
+      </dependency>
+      <dependency>
         <groupId>org.apache.httpcomponents</groupId>
         <artifactId>httpclient</artifactId>
         <version>4.5.13</version>

--- a/signalfx-java/pom.xml
+++ b/signalfx-java/pom.xml
@@ -81,6 +81,12 @@
       <artifactId>jackson-annotations</artifactId>
     </dependency>
     <dependency>
+      <!-- Temp work-around until httpclient upgrades its codec version -->
+      <groupId>commons-codec</groupId>
+      <artifactId>commons-codec</artifactId>
+      <version>1.15</version>
+    </dependency>
+    <dependency>
       <groupId>org.apache.httpcomponents</groupId>
       <artifactId>httpclient</artifactId>
     </dependency>


### PR DESCRIPTION
Mitigates https://security.snyk.io/vuln/SNYK-JAVA-COMMONSCODEC-561518

It sucks to do it this way, but it looks like the v4.x release of httpclient hasn't yet been updated (see the bottom comment from 6 months ago) https://issues.apache.org/jira/browse/HTTPCLIENT-2072