### PR TITLE
Yield message on END_OF_CHANNEL

### DIFF
--- a/signalfx-java/src/main/java/com/signalfx/signalflow/Computation.java
+++ b/signalfx-java/src/main/java/com/signalfx/signalflow/Computation.java
@@ -239,6 +239,7 @@ public class Computation implements Iterable<ChannelMessage>, Iterator<ChannelMe
 
                 case END_OF_CHANNEL:
                     state = State.STATE_COMPLETED;
+                    nextMessage = message;
                     break;
 
                 case METADATA_MESSAGE:


### PR DESCRIPTION
This change makes it possible to process END_OF_CHANNEL channel messages when iterating over computation.


```
for (ChannelMessage message : computation) {
            switch (message.getType()) {
                case DATA_MESSAGE, EVENT_MESSAGE, METADATA_MESSAGE, JOB_PROGRESS, JOB_START, STREAM_START, EXPIRED_TSID_MESSAGE, INFO_MESSAGE, ERROR_MESSAGE:
                    break;
                case CHANNEL_ABORT:
                    return;
                case END_OF_CHANNEL:
                    // this is now possible.
                    return;
            }
        }
```