### PR TITLE
Add a retry strategy with max retries

### DIFF
--- a/signalfx-java/src/main/java/com/signalfx/connection/AbstractHttpReceiverConnection.java
+++ b/signalfx-java/src/main/java/com/signalfx/connection/AbstractHttpReceiverConnection.java
@@ -38,11 +38,12 @@ public abstract class AbstractHttpReceiverConnection {
     protected final HttpHost host;
     protected final RequestConfig requestConfig;
 
-    protected AbstractHttpReceiverConnection(SignalFxReceiverEndpoint endpoint, int timeoutMs,
+    protected AbstractHttpReceiverConnection(SignalFxReceiverEndpoint endpoint, int timeoutMs, int maxRetries,
                                              HttpClientConnectionManager httpClientConnectionManager) {
         this.client = HttpClientBuilder.create()
                 .setConnectionManager(httpClientConnectionManager)
-                .setRetryHandler(new RetryHandler())
+                .setRetryHandler(new RetryHandler(maxRetries))
+                .setServiceUnavailableRetryStrategy(new RetryStrategy(maxRetries))
                 .build();
         this.host = new HttpHost(endpoint.getHostname(), endpoint.getPort(), endpoint.getScheme());
 

--- a/signalfx-java/src/main/java/com/signalfx/connection/AbstractHttpReceiverConnection.java
+++ b/signalfx-java/src/main/java/com/signalfx/connection/AbstractHttpReceiverConnection.java
@@ -22,6 +22,8 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.signalfx.endpoint.SignalFxReceiverEndpoint;
 import com.signalfx.metrics.SignalFxMetricsException;
 
+import static com.signalfx.connection.RetryHandler.DEFAULT_MAX_RETRIES;
+
 public abstract class AbstractHttpReceiverConnection {
 
     protected static final Logger log = LoggerFactory.getLogger(AbstractHttpReceiverConnection.class);
@@ -37,6 +39,11 @@ public abstract class AbstractHttpReceiverConnection {
     protected final CloseableHttpClient client;
     protected final HttpHost host;
     protected final RequestConfig requestConfig;
+
+    protected AbstractHttpReceiverConnection(SignalFxReceiverEndpoint endpoint, int timeoutMs,
+                                             HttpClientConnectionManager httpClientConnectionManager) {
+        this(endpoint, timeoutMs, DEFAULT_MAX_RETRIES, httpClientConnectionManager);
+    }
 
     protected AbstractHttpReceiverConnection(SignalFxReceiverEndpoint endpoint, int timeoutMs, int maxRetries,
                                              HttpClientConnectionManager httpClientConnectionManager) {

--- a/signalfx-java/src/main/java/com/signalfx/connection/RetryHandler.java
+++ b/signalfx-java/src/main/java/com/signalfx/connection/RetryHandler.java
@@ -15,8 +15,8 @@ import org.apache.http.impl.client.DefaultHttpRequestRetryHandler;
  */
 class RetryHandler extends DefaultHttpRequestRetryHandler {
 
-  public RetryHandler() {
-    super(3, true, Arrays.asList(
+  public RetryHandler(final int maxRetries) {
+    super(maxRetries, true, Arrays.asList(
         InterruptedIOException.class,
         UnknownHostException.class,
         ConnectException.class));

--- a/signalfx-java/src/main/java/com/signalfx/connection/RetryHandler.java
+++ b/signalfx-java/src/main/java/com/signalfx/connection/RetryHandler.java
@@ -14,11 +14,19 @@ import org.apache.http.impl.client.DefaultHttpRequestRetryHandler;
  * "stale" connections in such a way that http client is unable to detect this.
  */
 class RetryHandler extends DefaultHttpRequestRetryHandler {
+  public static final Integer DEFAULT_MAX_RETRIES = 3;
 
   public RetryHandler(final int maxRetries) {
     super(maxRetries, true, Arrays.asList(
         InterruptedIOException.class,
         UnknownHostException.class,
         ConnectException.class));
+  }
+
+  public RetryHandler() {
+    super(DEFAULT_MAX_RETRIES, true, Arrays.asList(
+            InterruptedIOException.class,
+            UnknownHostException.class,
+            ConnectException.class));
   }
 }

--- a/signalfx-java/src/main/java/com/signalfx/connection/RetryStrategy.java
+++ b/signalfx-java/src/main/java/com/signalfx/connection/RetryStrategy.java
@@ -1,0 +1,25 @@
+package com.signalfx.connection;
+
+import org.apache.http.HttpResponse;
+import org.apache.http.HttpStatus;
+import org.apache.http.client.ServiceUnavailableRetryStrategy;
+import org.apache.http.protocol.HttpContext;
+
+public class RetryStrategy implements ServiceUnavailableRetryStrategy {
+    private final int maxRetries;
+
+    public RetryStrategy(final int maxRetries) {
+        this.maxRetries = maxRetries;
+    }
+
+    @Override
+    public boolean retryRequest(final HttpResponse httpResponse, final int executionCount, final HttpContext httpContext) {
+        final int statusCode = httpResponse.getStatusLine().getStatusCode();
+        return executionCount <= maxRetries && (statusCode == HttpStatus.SC_REQUEST_TIMEOUT || statusCode == HttpStatus.SC_GATEWAY_TIMEOUT || statusCode == 598 || statusCode == -1);
+    }
+
+    @Override
+    public long getRetryInterval() {
+        return 0;
+    }
+}

--- a/signalfx-java/src/main/java/com/signalfx/metrics/connection/AbstractHttpDataPointProtobufReceiverConnection.java
+++ b/signalfx-java/src/main/java/com/signalfx/metrics/connection/AbstractHttpDataPointProtobufReceiverConnection.java
@@ -31,6 +31,13 @@ public abstract class AbstractHttpDataPointProtobufReceiverConnection extends Ab
 
     public AbstractHttpDataPointProtobufReceiverConnection(SignalFxReceiverEndpoint endpoint,
                                                            int timeoutMs,
+                                                           HttpClientConnectionManager httpClientConnectionManager) {
+        super(endpoint, timeoutMs, httpClientConnectionManager);
+        this.compress = !Boolean.getBoolean(DISABLE_COMPRESSION_PROPERTY);
+    }
+
+    public AbstractHttpDataPointProtobufReceiverConnection(SignalFxReceiverEndpoint endpoint,
+                                                           int timeoutMs,
                                                            int maxRetries,
                                                            HttpClientConnectionManager httpClientConnectionManager) {
         super(endpoint, timeoutMs, maxRetries, httpClientConnectionManager);

--- a/signalfx-java/src/main/java/com/signalfx/metrics/connection/AbstractHttpDataPointProtobufReceiverConnection.java
+++ b/signalfx-java/src/main/java/com/signalfx/metrics/connection/AbstractHttpDataPointProtobufReceiverConnection.java
@@ -31,8 +31,9 @@ public abstract class AbstractHttpDataPointProtobufReceiverConnection extends Ab
 
     public AbstractHttpDataPointProtobufReceiverConnection(SignalFxReceiverEndpoint endpoint,
                                                            int timeoutMs,
+                                                           int maxRetries,
                                                            HttpClientConnectionManager httpClientConnectionManager) {
-        super(endpoint, timeoutMs, httpClientConnectionManager);
+        super(endpoint, timeoutMs, maxRetries, httpClientConnectionManager);
         this.compress = !Boolean.getBoolean(DISABLE_COMPRESSION_PROPERTY);
     }
 

--- a/signalfx-java/src/main/java/com/signalfx/metrics/connection/AbstractHttpEventProtobufReceiverConnection.java
+++ b/signalfx-java/src/main/java/com/signalfx/metrics/connection/AbstractHttpEventProtobufReceiverConnection.java
@@ -19,8 +19,8 @@ public abstract class AbstractHttpEventProtobufReceiverConnection extends Abstra
 
     public AbstractHttpEventProtobufReceiverConnection(
             SignalFxReceiverEndpoint endpoint,
-            int timeoutMs, HttpClientConnectionManager httpClientConnectionManager) {
-        super(endpoint, timeoutMs, httpClientConnectionManager);
+            int timeoutMs, int maxRetries, HttpClientConnectionManager httpClientConnectionManager) {
+        super(endpoint, timeoutMs, maxRetries, httpClientConnectionManager);
     }
 
     @Override

--- a/signalfx-java/src/main/java/com/signalfx/metrics/connection/AbstractHttpEventProtobufReceiverConnection.java
+++ b/signalfx-java/src/main/java/com/signalfx/metrics/connection/AbstractHttpEventProtobufReceiverConnection.java
@@ -19,6 +19,12 @@ public abstract class AbstractHttpEventProtobufReceiverConnection extends Abstra
 
     public AbstractHttpEventProtobufReceiverConnection(
             SignalFxReceiverEndpoint endpoint,
+            int timeoutMs, HttpClientConnectionManager httpClientConnectionManager) {
+        super(endpoint, timeoutMs, httpClientConnectionManager);
+    }
+
+    public AbstractHttpEventProtobufReceiverConnection(
+            SignalFxReceiverEndpoint endpoint,
             int timeoutMs, int maxRetries, HttpClientConnectionManager httpClientConnectionManager) {
         super(endpoint, timeoutMs, maxRetries, httpClientConnectionManager);
     }

--- a/signalfx-java/src/main/java/com/signalfx/metrics/connection/HttpDataPointProtobufReceiverConnection.java
+++ b/signalfx-java/src/main/java/com/signalfx/metrics/connection/HttpDataPointProtobufReceiverConnection.java
@@ -26,9 +26,9 @@ import com.signalfx.metrics.protobuf.SignalFxProtocolBuffers;
 public class HttpDataPointProtobufReceiverConnection
         extends AbstractHttpDataPointProtobufReceiverConnection {
     public HttpDataPointProtobufReceiverConnection(
-            SignalFxReceiverEndpoint endpoint, int timeoutMs,
+            SignalFxReceiverEndpoint endpoint, int timeoutMs, int maxRetries,
             HttpClientConnectionManager httpClientConnectionManager) {
-        super(endpoint, timeoutMs, httpClientConnectionManager);
+        super(endpoint, timeoutMs, maxRetries, httpClientConnectionManager);
     }
 
     @Override

--- a/signalfx-java/src/main/java/com/signalfx/metrics/connection/HttpDataPointProtobufReceiverConnection.java
+++ b/signalfx-java/src/main/java/com/signalfx/metrics/connection/HttpDataPointProtobufReceiverConnection.java
@@ -26,6 +26,12 @@ import com.signalfx.metrics.protobuf.SignalFxProtocolBuffers;
 public class HttpDataPointProtobufReceiverConnection
         extends AbstractHttpDataPointProtobufReceiverConnection {
     public HttpDataPointProtobufReceiverConnection(
+            SignalFxReceiverEndpoint endpoint, int timeoutMs,
+            HttpClientConnectionManager httpClientConnectionManager) {
+        super(endpoint, timeoutMs, httpClientConnectionManager);
+    }
+
+    public HttpDataPointProtobufReceiverConnection(
             SignalFxReceiverEndpoint endpoint, int timeoutMs, int maxRetries,
             HttpClientConnectionManager httpClientConnectionManager) {
         super(endpoint, timeoutMs, maxRetries, httpClientConnectionManager);

--- a/signalfx-java/src/main/java/com/signalfx/metrics/connection/HttpDataPointProtobufReceiverConnectionV2.java
+++ b/signalfx-java/src/main/java/com/signalfx/metrics/connection/HttpDataPointProtobufReceiverConnectionV2.java
@@ -15,9 +15,9 @@ import com.signalfx.metrics.protobuf.SignalFxProtocolBuffers;
 public class HttpDataPointProtobufReceiverConnectionV2
         extends AbstractHttpDataPointProtobufReceiverConnection {
     public HttpDataPointProtobufReceiverConnectionV2(
-            SignalFxReceiverEndpoint endpoint, int timeoutMs,
+            SignalFxReceiverEndpoint endpoint, int timeoutMs, int maxRetries,
             HttpClientConnectionManager httpClientConnectionManager) {
-        super(endpoint, timeoutMs, httpClientConnectionManager);
+        super(endpoint, timeoutMs, maxRetries, httpClientConnectionManager);
     }
 
     @Override

--- a/signalfx-java/src/main/java/com/signalfx/metrics/connection/HttpDataPointProtobufReceiverConnectionV2.java
+++ b/signalfx-java/src/main/java/com/signalfx/metrics/connection/HttpDataPointProtobufReceiverConnectionV2.java
@@ -15,6 +15,12 @@ import com.signalfx.metrics.protobuf.SignalFxProtocolBuffers;
 public class HttpDataPointProtobufReceiverConnectionV2
         extends AbstractHttpDataPointProtobufReceiverConnection {
     public HttpDataPointProtobufReceiverConnectionV2(
+            SignalFxReceiverEndpoint endpoint, int timeoutMs,
+            HttpClientConnectionManager httpClientConnectionManager) {
+        super(endpoint, timeoutMs, httpClientConnectionManager);
+    }
+
+    public HttpDataPointProtobufReceiverConnectionV2(
             SignalFxReceiverEndpoint endpoint, int timeoutMs, int maxRetries,
             HttpClientConnectionManager httpClientConnectionManager) {
         super(endpoint, timeoutMs, maxRetries, httpClientConnectionManager);

--- a/signalfx-java/src/main/java/com/signalfx/metrics/connection/HttpDataPointProtobufReceiverFactory.java
+++ b/signalfx-java/src/main/java/com/signalfx/metrics/connection/HttpDataPointProtobufReceiverFactory.java
@@ -9,12 +9,14 @@ import com.signalfx.metrics.SignalFxMetricsException;
 public class HttpDataPointProtobufReceiverFactory implements DataPointReceiverFactory {
     public static final int DEFAULT_TIMEOUT_MS = 2000;
     public static final int DEFAULT_VERSION = 2;
+    public static final int DEFAULT_MAX_RETRIES = 3;
 
     private final SignalFxReceiverEndpoint endpoint;
     private HttpClientConnectionManager httpClientConnectionManager;
     private HttpClientConnectionManager explicitHttpClientConnectionManager;
     private int timeoutMs = DEFAULT_TIMEOUT_MS;
     private int version = DEFAULT_VERSION;
+    private int maxRetries = DEFAULT_MAX_RETRIES;
 
     public HttpDataPointProtobufReceiverFactory(SignalFxReceiverEndpoint endpoint) {
         this.endpoint = endpoint;
@@ -35,6 +37,11 @@ public class HttpDataPointProtobufReceiverFactory implements DataPointReceiverFa
         return this;
     }
 
+    public HttpDataPointProtobufReceiverFactory setMaxRetries(int maxRetries) {
+        this.maxRetries = maxRetries;
+        return this;
+    }
+
     public void setHttpClientConnectionManager(
             HttpClientConnectionManager httpClientConnectionManager) {
         this.explicitHttpClientConnectionManager = httpClientConnectionManager;
@@ -47,11 +54,13 @@ public class HttpDataPointProtobufReceiverFactory implements DataPointReceiverFa
             return new HttpDataPointProtobufReceiverConnection(
                 endpoint,
                 this.timeoutMs,
+                this.maxRetries,
                 resolveHttpClientConnectionManager());
         } else {
             return new HttpDataPointProtobufReceiverConnectionV2(
                 endpoint,
                 this.timeoutMs,
+                this.maxRetries,
                 resolveHttpClientConnectionManager());
         }
 

--- a/signalfx-java/src/main/java/com/signalfx/metrics/connection/HttpEventProtobufReceiverConnectionV2.java
+++ b/signalfx-java/src/main/java/com/signalfx/metrics/connection/HttpEventProtobufReceiverConnectionV2.java
@@ -12,9 +12,9 @@ import com.signalfx.metrics.protobuf.SignalFxProtocolBuffers;
 public class HttpEventProtobufReceiverConnectionV2
         extends AbstractHttpEventProtobufReceiverConnection {
     public HttpEventProtobufReceiverConnectionV2(
-            SignalFxReceiverEndpoint endpoint, int timeoutMs,
+            SignalFxReceiverEndpoint endpoint, int timeoutMs, int maxRetries,
             HttpClientConnectionManager httpClientConnectionManager) {
-        super(endpoint, timeoutMs, httpClientConnectionManager);
+        super(endpoint, timeoutMs, maxRetries, httpClientConnectionManager);
     }
 
     @Override

--- a/signalfx-java/src/main/java/com/signalfx/metrics/connection/HttpEventProtobufReceiverConnectionV2.java
+++ b/signalfx-java/src/main/java/com/signalfx/metrics/connection/HttpEventProtobufReceiverConnectionV2.java
@@ -12,6 +12,12 @@ import com.signalfx.metrics.protobuf.SignalFxProtocolBuffers;
 public class HttpEventProtobufReceiverConnectionV2
         extends AbstractHttpEventProtobufReceiverConnection {
     public HttpEventProtobufReceiverConnectionV2(
+            SignalFxReceiverEndpoint endpoint, int timeoutMs,
+            HttpClientConnectionManager httpClientConnectionManager) {
+        super(endpoint, timeoutMs, httpClientConnectionManager);
+    }
+
+    public HttpEventProtobufReceiverConnectionV2(
             SignalFxReceiverEndpoint endpoint, int timeoutMs, int maxRetries,
             HttpClientConnectionManager httpClientConnectionManager) {
         super(endpoint, timeoutMs, maxRetries, httpClientConnectionManager);

--- a/signalfx-java/src/main/java/com/signalfx/metrics/connection/HttpEventProtobufReceiverFactory.java
+++ b/signalfx-java/src/main/java/com/signalfx/metrics/connection/HttpEventProtobufReceiverFactory.java
@@ -9,12 +9,14 @@ import com.signalfx.metrics.SignalFxMetricsException;
 public class HttpEventProtobufReceiverFactory implements EventReceiverFactory {
     public static final int DEFAULT_TIMEOUT_MS = 2000;
     public static final int DEFAULT_VERSION = 2;
+    public static final int DEFAULT_MAX_RETRIES = 3;
 
     private final SignalFxReceiverEndpoint endpoint;
     private HttpClientConnectionManager httpClientConnectionManager;
     private HttpClientConnectionManager explicitHttpClientConnectionManager;
     private int timeoutMs = DEFAULT_TIMEOUT_MS;
     private int version = DEFAULT_VERSION;
+    private int maxRetries = DEFAULT_MAX_RETRIES;
 
     public HttpEventProtobufReceiverFactory(SignalFxReceiverEndpoint endpoint) {
         this.endpoint = endpoint;
@@ -35,6 +37,11 @@ public class HttpEventProtobufReceiverFactory implements EventReceiverFactory {
         return this;
     }
 
+    public HttpEventProtobufReceiverFactory setMaxRetries(int maxRetries) {
+        this.maxRetries = maxRetries;
+        return this;
+    }
+
     public void setHttpClientConnectionManager(
             HttpClientConnectionManager httpClientConnectionManager) {
         this.explicitHttpClientConnectionManager = httpClientConnectionManager;
@@ -47,6 +54,7 @@ public class HttpEventProtobufReceiverFactory implements EventReceiverFactory {
             return new HttpEventProtobufReceiverConnectionV2(
                 endpoint,
                 this.timeoutMs,
+                this.maxRetries,
                 resolveHttpClientConnectionManager());
         }else{
             throw new SignalFxMetricsException("Version v1 is deprecated, We encourage to use v2/event");

--- a/signalfx-java/src/main/java/com/signalfx/signalflow/ServerSentEventsTransport.java
+++ b/signalfx-java/src/main/java/com/signalfx/signalflow/ServerSentEventsTransport.java
@@ -47,11 +47,13 @@ public class ServerSentEventsTransport implements SignalFlowTransport {
 
     protected static final Logger log = LoggerFactory.getLogger(ServerSentEventsTransport.class);
     public static final Integer DEFAULT_TIMEOUT = 1000;
+    public static final Integer DEFAULT_MAX_RETRIES = 3;
 
     protected final String token;
     protected final SignalFxEndpoint endpoint;
     protected final String path;
     protected Integer timeout = DEFAULT_TIMEOUT;
+    protected Integer maxRetries = DEFAULT_MAX_RETRIES;
 
     protected ServerSentEventsTransport(String token, final SignalFxEndpoint endpoint,
                                         final int apiVersion, final Integer timeout) {
@@ -59,6 +61,15 @@ public class ServerSentEventsTransport implements SignalFlowTransport {
         this.endpoint = endpoint;
         this.path = "/v" + apiVersion + "/signalflow";
         this.timeout = timeout;
+    }
+
+    protected ServerSentEventsTransport(String token, final SignalFxEndpoint endpoint,
+                                        final int apiVersion, final Integer timeout, final Integer maxRetries) {
+        this.token = token;
+        this.endpoint = endpoint;
+        this.path = "/v" + apiVersion + "/signalflow";
+        this.timeout = timeout;
+        this.maxRetries = maxRetries;
     }
 
     @Override
@@ -70,7 +81,7 @@ public class ServerSentEventsTransport implements SignalFlowTransport {
         TransportConnection connection = null;
         CloseableHttpResponse response = null;
         try {
-            connection = new TransportConnection(this.endpoint, timeout);
+            connection = new TransportConnection(this.endpoint, timeout, maxRetries);
 
             response = connection.post(this.token, this.path + "/" + handle + "/attach", parameters,
                     null);
@@ -93,7 +104,7 @@ public class ServerSentEventsTransport implements SignalFlowTransport {
         TransportConnection connection = null;
         CloseableHttpResponse response = null;
         try {
-            connection = new TransportConnection(this.endpoint, timeout);
+            connection = new TransportConnection(this.endpoint, timeout, maxRetries);
 
             response = connection.post(this.token, this.path + "/execute", parameters, program);
 
@@ -115,7 +126,7 @@ public class ServerSentEventsTransport implements SignalFlowTransport {
         TransportConnection connection = null;
         CloseableHttpResponse response = null;
         try {
-            connection = new TransportConnection(this.endpoint, timeout);
+            connection = new TransportConnection(this.endpoint, timeout, maxRetries);
 
             response = connection.post(this.token, this.path + "/preflight", parameters, program);
 
@@ -135,7 +146,7 @@ public class ServerSentEventsTransport implements SignalFlowTransport {
         TransportConnection connection = null;
         CloseableHttpResponse response = null;
         try {
-            connection = new TransportConnection(this.endpoint, timeout);
+            connection = new TransportConnection(this.endpoint, timeout, maxRetries);
             response = connection.post(this.token, this.path + "/start", parameters, program);
         } catch (Exception ex) {
             throw new SignalFlowException("failed to start program - " + program, ex);
@@ -154,7 +165,7 @@ public class ServerSentEventsTransport implements SignalFlowTransport {
         TransportConnection connection = null;
         CloseableHttpResponse response = null;
         try {
-            connection = new TransportConnection(this.endpoint, timeout);
+            connection = new TransportConnection(this.endpoint, timeout, maxRetries);
             response = connection.post(this.token, this.path + "/" + handle + "/stop", parameters,
                     null);
         } catch (Exception ex) {
@@ -174,7 +185,7 @@ public class ServerSentEventsTransport implements SignalFlowTransport {
         TransportConnection connection = null;
         CloseableHttpResponse response = null;
         try {
-            connection = new TransportConnection(this.endpoint, timeout);
+            connection = new TransportConnection(this.endpoint, timeout, maxRetries);
             response = connection.post(this.token, this.path + "/" + handle + "/keepalive", null,
                     null);
         } catch (Exception ex) {
@@ -266,14 +277,15 @@ public class ServerSentEventsTransport implements SignalFlowTransport {
 
         protected static final Logger log = LoggerFactory.getLogger(TransportConnection.class);
         public static final int DEFAULT_TIMEOUT_MS = 1000;
+        public static final int DEFAULT_MAX_RETRIES = 3;
         protected final RequestConfig transportRequestConfig;
 
         public TransportConnection(SignalFxEndpoint endpoint) {
-            this(endpoint, DEFAULT_TIMEOUT_MS);
+            this(endpoint, DEFAULT_TIMEOUT_MS, DEFAULT_MAX_RETRIES);
         }
 
-        public TransportConnection(SignalFxEndpoint endpoint, int timeoutMs) {
-            super(endpoint, timeoutMs, new BasicHttpClientConnectionManager());
+        public TransportConnection(SignalFxEndpoint endpoint, int timeoutMs, int maxRetries) {
+            super(endpoint, timeoutMs, maxRetries, new BasicHttpClientConnectionManager());
 
             this.transportRequestConfig = RequestConfig.custom().setSocketTimeout(0)
                     .setConnectionRequestTimeout(this.requestConfig.getConnectionRequestTimeout())

--- a/signalfx-java/src/main/java/com/signalfx/signalflow/ServerSentEventsTransport.java
+++ b/signalfx-java/src/main/java/com/signalfx/signalflow/ServerSentEventsTransport.java
@@ -55,15 +55,12 @@ public class ServerSentEventsTransport implements SignalFlowTransport {
     protected Integer timeout = DEFAULT_TIMEOUT;
     protected Integer maxRetries = DEFAULT_MAX_RETRIES;
 
-    protected ServerSentEventsTransport(String token, final SignalFxEndpoint endpoint,
+    protected ServerSentEventsTransport(final String token, final SignalFxEndpoint endpoint,
                                         final int apiVersion, final Integer timeout) {
-        this.token = token;
-        this.endpoint = endpoint;
-        this.path = "/v" + apiVersion + "/signalflow";
-        this.timeout = timeout;
+        this(token, endpoint, apiVersion, timeout, DEFAULT_MAX_RETRIES);
     }
 
-    protected ServerSentEventsTransport(String token, final SignalFxEndpoint endpoint,
+    protected ServerSentEventsTransport(final String token, final SignalFxEndpoint endpoint,
                                         final int apiVersion, final Integer timeout, final Integer maxRetries) {
         this.token = token;
         this.endpoint = endpoint;

--- a/signalfx-java/src/test/java/com/signalfx/connection/RetryStrategyTest.java
+++ b/signalfx-java/src/test/java/com/signalfx/connection/RetryStrategyTest.java
@@ -1,0 +1,100 @@
+package com.signalfx.connection;
+
+import org.apache.http.HttpResponse;
+import org.apache.http.HttpStatus;
+import org.apache.http.ProtocolVersion;
+import org.apache.http.StatusLine;
+import org.apache.http.client.protocol.HttpClientContext;
+import org.apache.http.impl.DefaultHttpResponseFactory;
+import org.apache.http.protocol.HttpContext;
+import org.junit.Test;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class RetryStrategyTest {
+    @Test
+    public void shouldSetRetryOnRequestTimeout() {
+        final RetryStrategy retryStrategy = new RetryStrategy(3);
+
+        final StatusLine mockStatusLine = generateStatusLineByCode(HttpStatus.SC_REQUEST_TIMEOUT);
+        final HttpContext mockHttpContext = new HttpClientContext();
+        final HttpResponse mockResp = DefaultHttpResponseFactory.INSTANCE.newHttpResponse(mockStatusLine, mockHttpContext);
+
+        assertTrue(retryStrategy.retryRequest(mockResp, 1, mockHttpContext));
+    }
+
+    @Test
+    public void shouldSetRetryOnGatewayTimeout() {
+        final RetryStrategy retryStrategy = new RetryStrategy(3);
+
+        final StatusLine mockStatusLine = generateStatusLineByCode(HttpStatus.SC_GATEWAY_TIMEOUT);
+        final HttpContext mockHttpContext = new HttpClientContext();
+        final HttpResponse mockResp = DefaultHttpResponseFactory.INSTANCE.newHttpResponse(mockStatusLine, mockHttpContext);
+
+        assertTrue(retryStrategy.retryRequest(mockResp, 1, mockHttpContext));
+    }
+
+    @Test
+    public void shouldSetRetryOnNegativeStatus() {
+        final RetryStrategy retryStrategy = new RetryStrategy(3);
+
+        final StatusLine mockStatusLine = generateStatusLineByCode(-1);
+        final HttpContext mockHttpContext = new HttpClientContext();
+        final HttpResponse mockResp = DefaultHttpResponseFactory.INSTANCE.newHttpResponse(mockStatusLine, mockHttpContext);
+
+        assertTrue(retryStrategy.retryRequest(mockResp, 1, mockHttpContext));
+    }
+
+    @Test
+    public void shouldSetRetryOnInvalidStatusCode() {
+        final RetryStrategy retryStrategy = new RetryStrategy(3);
+
+        final StatusLine mockStatusLine = generateStatusLineByCode(598);
+        final HttpContext mockHttpContext = new HttpClientContext();
+        final HttpResponse mockResp = DefaultHttpResponseFactory.INSTANCE.newHttpResponse(mockStatusLine, mockHttpContext);
+
+        assertTrue(retryStrategy.retryRequest(mockResp, 1, mockHttpContext));
+    }
+
+    @Test
+    public void shouldNotRetryOnOtherStatusCode() {
+        final RetryStrategy retryStrategy = new RetryStrategy(3);
+
+        final StatusLine mockStatusLine = generateStatusLineByCode(HttpStatus.SC_BAD_GATEWAY);
+        final HttpContext mockHttpContext = new HttpClientContext();
+        final HttpResponse mockResp = DefaultHttpResponseFactory.INSTANCE.newHttpResponse(mockStatusLine, mockHttpContext);
+
+        assertFalse(retryStrategy.retryRequest(mockResp, 1, mockHttpContext));
+    }
+
+    @Test
+    public void shouldNotRetryIfRetriesExceeded() {
+        final RetryStrategy retryStrategy = new RetryStrategy(3);
+
+        final StatusLine mockStatusLine = generateStatusLineByCode(HttpStatus.SC_GATEWAY_TIMEOUT);
+        final HttpContext mockHttpContext = new HttpClientContext();
+        final HttpResponse mockResp = DefaultHttpResponseFactory.INSTANCE.newHttpResponse(mockStatusLine, mockHttpContext);
+
+        assertFalse(retryStrategy.retryRequest(mockResp, 4, mockHttpContext));
+    }
+
+    private StatusLine generateStatusLineByCode(final int statusCode) {
+        return new StatusLine() {
+            @Override
+            public ProtocolVersion getProtocolVersion() {
+                return null;
+            }
+
+            @Override
+            public int getStatusCode() {
+                return statusCode;
+            }
+
+            @Override
+            public String getReasonPhrase() {
+                return null;
+            }
+        };
+    }
+}


### PR DESCRIPTION
We encounter a bunch of errors accessing the sfx endpoints that are potentially retryable and we want to make this property configurable.