### PR TITLE
Add support to emit delta histogram count buckets for Timer and DistributionSummary

### DIFF
--- a/micrometer-registry-signalfx/README.md
+++ b/micrometer-registry-signalfx/README.md
@@ -2,5 +2,5 @@
 
 **:warning:
 This is a temporary, one-time fork of the Micrometer Registry for SignalFx project. 
-It will not be updated, and will be removed once Micrometer 1.9.0 is released.
+It will not be updated, and will be removed once Micrometer 1.10.0 is released.
 :warning:**

--- a/micrometer-registry-signalfx/src/main/java/io/micrometer/signalfx/DeltaHistogramSnapshot.java
+++ b/micrometer-registry-signalfx/src/main/java/io/micrometer/signalfx/DeltaHistogramSnapshot.java
@@ -20,23 +20,14 @@ import io.micrometer.core.instrument.distribution.CountAtBucket;
 import io.micrometer.core.instrument.distribution.HistogramSnapshot;
 
 final class DeltaHistogramSnapshot {
-    // It may get called from different threads, so use volatile to ensure updates are visible.
-    // Not null only if producing delta.
-    private volatile HistogramSnapshot lastSnapshot;
+    private HistogramSnapshot lastSnapshot;
 
-    DeltaHistogramSnapshot(boolean isDelta) {
-        if (isDelta) {
-            lastSnapshot = HistogramSnapshot.empty(0, 0, 0);
-        } else {
-            lastSnapshot = null;
-        }
+    DeltaHistogramSnapshot() {
+        lastSnapshot = HistogramSnapshot.empty(0, 0, 0);
     }
 
     // TODO: Determine if we need to synchronize, in case multiple calls in parallel.
     HistogramSnapshot calculateSnapshot(HistogramSnapshot currentSnapshot) {
-        if (lastSnapshot == null) {
-            return currentSnapshot;
-        }
         HistogramSnapshot deltaSnapshot = new HistogramSnapshot(
                 currentSnapshot.count() - lastSnapshot.count(),
                 currentSnapshot.total() - lastSnapshot.total(),

--- a/micrometer-registry-signalfx/src/main/java/io/micrometer/signalfx/DeltaHistogramSnapshot.java
+++ b/micrometer-registry-signalfx/src/main/java/io/micrometer/signalfx/DeltaHistogramSnapshot.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright Splunk Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.micrometer.signalfx;
+
+import io.micrometer.core.instrument.distribution.CountAtBucket;
+import io.micrometer.core.instrument.distribution.HistogramSnapshot;
+
+final class DeltaHistogramSnapshot {
+    // It may get called from different threads, so use volatile to ensure updates are visible.
+    // Not null only if producing delta.
+    private volatile HistogramSnapshot lastSnapshot;
+
+    DeltaHistogramSnapshot(boolean isDelta) {
+        if (isDelta) {
+            lastSnapshot = HistogramSnapshot.empty(0, 0, 0);
+        } else {
+            lastSnapshot = null;
+        }
+    }
+
+    // TODO: Determine if we need to synchronize, in case multiple calls in parallel.
+    HistogramSnapshot calculateSnapshot(HistogramSnapshot currentSnapshot) {
+        if (lastSnapshot == null) {
+            return currentSnapshot;
+        }
+        HistogramSnapshot deltaSnapshot = new HistogramSnapshot(
+                currentSnapshot.count() - lastSnapshot.count(),
+                currentSnapshot.total() - lastSnapshot.total(),
+                currentSnapshot.max(),  // Max cannot be calculated as delta, keep the current.
+                null,  // No percentile values
+                deltaHistogramCounts(currentSnapshot),
+                currentSnapshot::outputSummary);
+        lastSnapshot = currentSnapshot;
+        return deltaSnapshot;
+    }
+
+    private CountAtBucket[] deltaHistogramCounts(HistogramSnapshot currentSnapshot) {
+        CountAtBucket[] currentHistogramCounts = currentSnapshot.histogramCounts();
+        CountAtBucket[] lastHistogramCounts = lastSnapshot.histogramCounts();
+        if (lastHistogramCounts == null || lastHistogramCounts.length == 0) {
+            return currentHistogramCounts;
+        }
+
+        CountAtBucket[] retHistogramCounts = new CountAtBucket[currentHistogramCounts.length];
+        for (int i = 0; i < currentHistogramCounts.length; i++) {
+            retHistogramCounts[i] = new CountAtBucket(
+                    currentHistogramCounts[i].bucket(),
+                    currentHistogramCounts[i].count() - lastHistogramCounts[i].count());
+        }
+        return retHistogramCounts;
+    }
+}

--- a/micrometer-registry-signalfx/src/main/java/io/micrometer/signalfx/DeltaHistogramSnapshot.java
+++ b/micrometer-registry-signalfx/src/main/java/io/micrometer/signalfx/DeltaHistogramSnapshot.java
@@ -19,6 +19,7 @@ package io.micrometer.signalfx;
 import io.micrometer.core.instrument.distribution.CountAtBucket;
 import io.micrometer.core.instrument.distribution.HistogramSnapshot;
 
+// WARNING: This class is not available upstream yet, but will be soon, and may suffer modifications.
 final class DeltaHistogramSnapshot {
     private HistogramSnapshot lastSnapshot;
 

--- a/micrometer-registry-signalfx/src/main/java/io/micrometer/signalfx/SignalFxConfig.java
+++ b/micrometer-registry-signalfx/src/main/java/io/micrometer/signalfx/SignalFxConfig.java
@@ -64,12 +64,23 @@ public interface SignalFxConfig extends StepRegistryConfig {
     }
 
     /**
-     * @return {@code true} if the SignalFx registry should emit cumulative histogram
-     * buckets.
+     * If both "publishCumulativeHistogram" and "publishDeltaHistogram" are set, then delta will be used.
+     *
+     * @return {@code true} if the SignalFx registry should emit cumulative histogram buckets.
      * @since 1.9.0
      */
     default boolean publishCumulativeHistogram() {
         return getBoolean(this, "publishCumulativeHistogram").orElse(false);
+    }
+
+    /**
+     * If both "publishCumulativeHistogram" and "publishDeltaHistogram" are set, then delta will be used.
+     *
+     * @return {@code true} if the SignalFx registry should emit delta histogram buckets.
+     * @since 1.10.0
+     */
+    default boolean publishDeltaHistogram() {
+        return getBoolean(this, "publishDeltaHistogram").orElse(false);
     }
 
     /**

--- a/micrometer-registry-signalfx/src/main/java/io/micrometer/signalfx/SignalFxConfig.java
+++ b/micrometer-registry-signalfx/src/main/java/io/micrometer/signalfx/SignalFxConfig.java
@@ -64,8 +64,6 @@ public interface SignalFxConfig extends StepRegistryConfig {
     }
 
     /**
-     * If both "publishCumulativeHistogram" and "publishDeltaHistogram" are set, then delta will be used.
-     *
      * @return {@code true} if the SignalFx registry should emit cumulative histogram buckets.
      * @since 1.9.0
      */
@@ -75,6 +73,8 @@ public interface SignalFxConfig extends StepRegistryConfig {
 
     /**
      * If both "publishCumulativeHistogram" and "publishDeltaHistogram" are set, then delta will be used.
+     *
+     * <p>WARNING: This configuration is not available upstream yet, but will be soon, and may suffer modifications.
      *
      * @return {@code true} if the SignalFx registry should emit delta histogram buckets.
      * @since 1.10.0

--- a/micrometer-registry-signalfx/src/main/java/io/micrometer/signalfx/SignalFxMeterRegistry.java
+++ b/micrometer-registry-signalfx/src/main/java/io/micrometer/signalfx/SignalFxMeterRegistry.java
@@ -172,7 +172,7 @@ public class SignalFxMeterRegistry extends StepMeterRegistry {
             return super.newTimer(id, distributionStatisticConfig, pauseDetector);
         }
         Timer timer = new SignalfxTimer(id, clock, distributionStatisticConfig, pauseDetector, getBaseTimeUnit(),
-                config.step().toMillis(), this.publishDeltaHistogram);
+                config.step().toMillis(), publishDeltaHistogram);
         HistogramGauges.registerWithCommonFormat(timer, this);
         return timer;
     }
@@ -184,7 +184,7 @@ public class SignalFxMeterRegistry extends StepMeterRegistry {
             return super.newDistributionSummary(id, distributionStatisticConfig, scale);
         }
         DistributionSummary summary = new SignalfxDistributionSummary(id, clock, distributionStatisticConfig, scale,
-                config.step().toMillis(), this.publishDeltaHistogram);
+                config.step().toMillis(), publishDeltaHistogram);
         HistogramGauges.registerWithCommonFormat(summary, this);
         return summary;
     }

--- a/micrometer-registry-signalfx/src/main/java/io/micrometer/signalfx/SignalFxMeterRegistry.java
+++ b/micrometer-registry-signalfx/src/main/java/io/micrometer/signalfx/SignalFxMeterRegistry.java
@@ -99,6 +99,8 @@ public class SignalFxMeterRegistry extends StepMeterRegistry {
 
     private final boolean publishCumulativeHistogram;
 
+    private final boolean publishDeltaHistogram;
+
     public SignalFxMeterRegistry(SignalFxConfig config, Clock clock) {
         this(config, clock, DEFAULT_THREAD_FACTORY);
     }
@@ -122,6 +124,7 @@ public class SignalFxMeterRegistry extends StepMeterRegistry {
         this.dataPointReceiverFactory = new HttpDataPointProtobufReceiverFactory(signalFxEndpoint);
         this.eventReceiverFactory = new HttpEventProtobufReceiverFactory(signalFxEndpoint);
         this.publishCumulativeHistogram = config.publishCumulativeHistogram();
+        this.publishDeltaHistogram = config.publishDeltaHistogram();
 
         config().namingConvention(new SignalFxNamingConvention());
 
@@ -165,11 +168,11 @@ public class SignalFxMeterRegistry extends StepMeterRegistry {
     @Override
     protected Timer newTimer(Meter.Id id, DistributionStatisticConfig distributionStatisticConfig,
             PauseDetector pauseDetector) {
-        if (!publishCumulativeHistogram) {
+        if (!publishCumulativeHistogram && !publishDeltaHistogram) {
             return super.newTimer(id, distributionStatisticConfig, pauseDetector);
         }
         Timer timer = new SignalfxTimer(id, clock, distributionStatisticConfig, pauseDetector, getBaseTimeUnit(),
-                config.step().toMillis());
+                config.step().toMillis(), this.publishDeltaHistogram);
         HistogramGauges.registerWithCommonFormat(timer, this);
         return timer;
     }
@@ -177,11 +180,11 @@ public class SignalFxMeterRegistry extends StepMeterRegistry {
     @Override
     protected DistributionSummary newDistributionSummary(Meter.Id id,
             DistributionStatisticConfig distributionStatisticConfig, double scale) {
-        if (!publishCumulativeHistogram) {
+        if (!publishCumulativeHistogram && !publishDeltaHistogram) {
             return super.newDistributionSummary(id, distributionStatisticConfig, scale);
         }
         DistributionSummary summary = new SignalfxDistributionSummary(id, clock, distributionStatisticConfig, scale,
-                config.step().toMillis());
+                config.step().toMillis(), this.publishDeltaHistogram);
         HistogramGauges.registerWithCommonFormat(summary, this);
         return summary;
     }
@@ -237,6 +240,10 @@ public class SignalFxMeterRegistry extends StepMeterRegistry {
     }
 
     Stream<SignalFxProtocolBuffers.DataPoint.Builder> addGauge(Gauge gauge) {
+        if (publishDeltaHistogram && gauge.getId().syntheticAssociation() != null
+                && gauge.getId().getName().endsWith(".histogram")) {
+            return Stream.of(addDatapoint(gauge, COUNTER, null, gauge.value()));
+        }
         if (publishCumulativeHistogram && gauge.getId().syntheticAssociation() != null
                 && gauge.getId().getName().endsWith(".histogram")) {
             return Stream.of(addDatapoint(gauge, CUMULATIVE_COUNTER, null, gauge.value()));

--- a/micrometer-registry-signalfx/src/main/java/io/micrometer/signalfx/SignalfxDistributionSummary.java
+++ b/micrometer-registry-signalfx/src/main/java/io/micrometer/signalfx/SignalfxDistributionSummary.java
@@ -69,7 +69,11 @@ final class SignalfxDistributionSummary extends AbstractDistributionSummary {
         super(id, clock, CumulativeHistogramConfigUtil.updateConfig(distributionStatisticConfig), scale, false);
         this.countTotal = new StepTuple2<>(clock, stepMillis, 0L, 0.0, count::sumThenReset, total::sumThenReset);
         this.max = new TimeWindowMax(clock, distributionStatisticConfig);
-        this.deltaHistogramSnapshot = new DeltaHistogramSnapshot(isDelta);
+        if (isDelta) {
+            deltaHistogramSnapshot = new DeltaHistogramSnapshot();
+        } else {
+            deltaHistogramSnapshot = null;
+        }
     }
 
     @Override
@@ -96,6 +100,9 @@ final class SignalfxDistributionSummary extends AbstractDistributionSummary {
 
     @Override
     public HistogramSnapshot takeSnapshot() {
-        return deltaHistogramSnapshot.calculateSnapshot(super.takeSnapshot());
+        if (deltaHistogramSnapshot != null) {
+            return deltaHistogramSnapshot.calculateSnapshot(super.takeSnapshot());
+        }
+        return super.takeSnapshot();
     }
 }

--- a/micrometer-registry-signalfx/src/test/java/io/micrometer/signalfx/DeltaHistogramSnapshotTest.java
+++ b/micrometer-registry-signalfx/src/test/java/io/micrometer/signalfx/DeltaHistogramSnapshotTest.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright Splunk Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.micrometer.signalfx;
+
+import io.micrometer.core.instrument.distribution.CountAtBucket;
+import io.micrometer.core.instrument.distribution.HistogramSnapshot;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class DeltaHistogramSnapshotTest {
+
+    @Test
+    void empty() {
+        DeltaHistogramSnapshot deltaHistogramSnapshot = new DeltaHistogramSnapshot();
+        HistogramSnapshot empty = HistogramSnapshot.empty(0, 0, 0);
+        assertEqualSnapshot(deltaHistogramSnapshot.calculateSnapshot(empty), empty);
+    }
+
+    @Test
+    void nonEmpty() {
+        DeltaHistogramSnapshot deltaHistogramSnapshot = new DeltaHistogramSnapshot();
+        HistogramSnapshot first = new HistogramSnapshot(
+                1, 2, 3, null,
+                new CountAtBucket[]{
+                        new CountAtBucket(1.0, 0),
+                        new CountAtBucket(5.0, 1),
+                        new CountAtBucket(Double.MAX_VALUE, 1)},
+                (printStream, aDouble) -> {});
+        assertEqualSnapshot(deltaHistogramSnapshot.calculateSnapshot(first), first);
+        HistogramSnapshot second = new HistogramSnapshot(
+                3, 10, 5.5, null,
+                new CountAtBucket[]{
+                        new CountAtBucket(1.0, 0),
+                        new CountAtBucket(5.0, 2),
+                        new CountAtBucket(Double.MAX_VALUE, 3)},
+                (printStream, aDouble) -> {});
+        assertEqualSnapshot(deltaHistogramSnapshot.calculateSnapshot(second), new HistogramSnapshot(
+                2, 8, 5.5, null,
+                new CountAtBucket[]{
+                        new CountAtBucket(1.0, 0),
+                        new CountAtBucket(5.0, 1),
+                        new CountAtBucket(Double.MAX_VALUE, 2)},
+                (printStream, aDouble) -> {}));
+    }
+
+    // Cannot directly use assertThat(got).isEqualTo(want) because HistogramSnapshot does not implement equals.
+    private static void assertEqualSnapshot(HistogramSnapshot got, HistogramSnapshot want) {
+        assertThat(got.count()).isEqualTo(want.count());
+        assertThat(got.total()).isEqualTo(want.total());
+        assertThat(got.max()).isEqualTo(want.max());
+        assertThat(got.percentileValues()).isEqualTo(want.percentileValues());
+        assertThat(got.histogramCounts()).isEqualTo(want.histogramCounts());
+    }
+}

--- a/micrometer-registry-signalfx/src/test/java/io/micrometer/signalfx/SignalFxMeterRegistryTest.java
+++ b/micrometer-registry-signalfx/src/test/java/io/micrometer/signalfx/SignalFxMeterRegistryTest.java
@@ -108,6 +108,33 @@ class SignalFxMeterRegistryTest {
         }
     };
 
+    private final SignalFxConfig cumulativeDeltaConfig = new SignalFxConfig() {
+        @Override
+        public String get(String key) {
+            return null;
+        }
+
+        @Override
+        public boolean enabled() {
+            return false;
+        }
+
+        @Override
+        public boolean publishDeltaHistogram() {
+            return true;
+        }
+
+        @Override
+        public boolean publishCumulativeHistogram() {
+            return true;
+        }
+
+        @Override
+        public String accessToken() {
+            return "accessToken";
+        }
+    };
+
     @Test
     void shouldConfigureCumulativeHistogram_Timer() {
         MockClock clock = new MockClock();
@@ -187,6 +214,73 @@ class SignalFxMeterRegistryTest {
                 .has(gaugePoint("my.timer.max", 2), atIndex(7))
                 .has(counterPoint("my.timer.totalTime", 2.2), atIndex(8));
 
+        timer.record(5, TimeUnit.MILLISECONDS);
+        timer.record(20, TimeUnit.MILLISECONDS);
+        timer.record(175, TimeUnit.MILLISECONDS);
+        timer.record(2, TimeUnit.SECONDS);
+
+        // Advance time, so we are in the "next" step where currently recorded values will
+        // be reported.
+        mockClock.add(config.step());
+
+        assertThat(getDataPoints(registry, mockClock.wallTime())).hasSize(9)
+                .has(gaugePoint("my.timer.avg", 0.55), atIndex(0)).has(counterPoint("my.timer.count", 4), atIndex(1))
+                .has(allOf(cumulativeCounterPoint("my.timer.histogram", 8), bucket("+Inf")), atIndex(2))
+                .has(allOf(cumulativeCounterPoint("my.timer.histogram", 0), bucket(buckets[0])), atIndex(3))
+                .has(allOf(cumulativeCounterPoint("my.timer.histogram", 2), bucket(buckets[1])), atIndex(4))
+                .has(allOf(cumulativeCounterPoint("my.timer.histogram", 4), bucket(buckets[2])), atIndex(5))
+                .has(allOf(cumulativeCounterPoint("my.timer.histogram", 6), bucket(buckets[3])), atIndex(6))
+                .has(gaugePoint("my.timer.max", 2), atIndex(7))
+                .has(counterPoint("my.timer.totalTime", 2.2), atIndex(8));
+
+        registry.close();
+    }
+
+    @ParameterizedTest
+    @ArgumentsSource(TimerBuckets.class)
+    void shouldExportDeltaHistogramData_Timer(Duration[] buckets) {
+        MockClock mockClock = new MockClock();
+        SignalFxMeterRegistry registry = new SignalFxMeterRegistry(cumulativeDeltaConfig, mockClock);
+        Timer timer = Timer.builder("my.timer").serviceLevelObjectives(buckets).register(registry);
+
+        timer.record(5, TimeUnit.MILLISECONDS);
+        timer.record(20, TimeUnit.MILLISECONDS);
+        timer.record(175, TimeUnit.MILLISECONDS);
+        timer.record(2, TimeUnit.SECONDS);
+
+        // Advance time, so we are in the "next" step where currently recorded values will
+        // be reported.
+        mockClock.add(config.step());
+
+        assertThat(getDataPoints(registry, mockClock.wallTime())).hasSize(9)
+                .has(gaugePoint("my.timer.avg", 0.55), atIndex(0)).has(counterPoint("my.timer.count", 4), atIndex(1))
+                .has(allOf(counterPoint("my.timer.histogram", 4), bucket("+Inf")), atIndex(2))
+                .has(allOf(counterPoint("my.timer.histogram", 0), bucket(buckets[0])), atIndex(3))
+                .has(allOf(counterPoint("my.timer.histogram", 1), bucket(buckets[1])), atIndex(4))
+                .has(allOf(counterPoint("my.timer.histogram", 2), bucket(buckets[2])), atIndex(5))
+                .has(allOf(counterPoint("my.timer.histogram", 3), bucket(buckets[3])), atIndex(6))
+                .has(gaugePoint("my.timer.max", 2), atIndex(7))
+                .has(counterPoint("my.timer.totalTime", 2.2), atIndex(8));
+
+        timer.record(5, TimeUnit.MILLISECONDS);
+        timer.record(20, TimeUnit.MILLISECONDS);
+        timer.record(175, TimeUnit.MILLISECONDS);
+        timer.record(2, TimeUnit.SECONDS);
+
+        // Advance time, so we are in the "next" step where currently recorded values will
+        // be reported.
+        mockClock.add(config.step());
+
+        assertThat(getDataPoints(registry, mockClock.wallTime())).hasSize(9)
+                .has(gaugePoint("my.timer.avg", 0.55), atIndex(0)).has(counterPoint("my.timer.count", 4), atIndex(1))
+                .has(allOf(counterPoint("my.timer.histogram", 4), bucket("+Inf")), atIndex(2))
+                .has(allOf(counterPoint("my.timer.histogram", 0), bucket(buckets[0])), atIndex(3))
+                .has(allOf(counterPoint("my.timer.histogram", 1), bucket(buckets[1])), atIndex(4))
+                .has(allOf(counterPoint("my.timer.histogram", 2), bucket(buckets[2])), atIndex(5))
+                .has(allOf(counterPoint("my.timer.histogram", 3), bucket(buckets[3])), atIndex(6))
+                .has(gaugePoint("my.timer.max", 2), atIndex(7))
+                .has(counterPoint("my.timer.totalTime", 2.2), atIndex(8));
+
         registry.close();
     }
 
@@ -228,6 +322,77 @@ class SignalFxMeterRegistryTest {
                 .has(allOf(cumulativeCounterPoint("my.distribution.histogram", 1), bucket(buckets[1])), atIndex(4))
                 .has(allOf(cumulativeCounterPoint("my.distribution.histogram", 2), bucket(buckets[2])), atIndex(5))
                 .has(allOf(cumulativeCounterPoint("my.distribution.histogram", 3), bucket(buckets[3])), atIndex(6))
+                .has(gaugePoint("my.distribution.max", 2000), atIndex(7))
+                .has(counterPoint("my.distribution.totalTime", 2200), atIndex(8));
+
+        distributionSummary.record(5);
+        distributionSummary.record(20);
+        distributionSummary.record(175);
+        distributionSummary.record(2000);
+
+        // Advance time, so we are in the "next" step where currently recorded values will
+        // be reported.
+        mockClock.add(cumulativeHistogramConfig.step());
+
+        assertThat(getDataPoints(registry, mockClock.wallTime())).hasSize(9)
+                .has(gaugePoint("my.distribution.avg", 550), atIndex(0))
+                .has(counterPoint("my.distribution.count", 4), atIndex(1))
+                .has(allOf(cumulativeCounterPoint("my.distribution.histogram", 8), bucket("+Inf")), atIndex(2))
+                .has(allOf(cumulativeCounterPoint("my.distribution.histogram", 0), bucket(buckets[0])), atIndex(3))
+                .has(allOf(cumulativeCounterPoint("my.distribution.histogram", 2), bucket(buckets[1])), atIndex(4))
+                .has(allOf(cumulativeCounterPoint("my.distribution.histogram", 4), bucket(buckets[2])), atIndex(5))
+                .has(allOf(cumulativeCounterPoint("my.distribution.histogram", 6), bucket(buckets[3])), atIndex(6))
+                .has(gaugePoint("my.distribution.max", 2000), atIndex(7))
+                .has(counterPoint("my.distribution.totalTime", 2200), atIndex(8));
+
+        registry.close();
+    }
+
+    @ParameterizedTest
+    @ArgumentsSource(DistributionSummaryBuckets.class)
+    void shouldExportDeltaHistogramData_DistributionSummary(double[] buckets) {
+        MockClock mockClock = new MockClock();
+        SignalFxMeterRegistry registry = new SignalFxMeterRegistry(cumulativeDeltaConfig, mockClock);
+        DistributionSummary distributionSummary = DistributionSummary.builder("my.distribution")
+                .serviceLevelObjectives(buckets).register(registry);
+
+        distributionSummary.record(5);
+        distributionSummary.record(20);
+        distributionSummary.record(175);
+        distributionSummary.record(2000);
+
+        // Advance time, so we are in the "next" step where currently recorded values will
+        // be reported.
+        mockClock.add(cumulativeHistogramConfig.step());
+
+        assertThat(getDataPoints(registry, mockClock.wallTime())).hasSize(9)
+                .has(gaugePoint("my.distribution.avg", 550), atIndex(0))
+                .has(counterPoint("my.distribution.count", 4), atIndex(1))
+                .has(allOf(counterPoint("my.distribution.histogram", 4), bucket("+Inf")), atIndex(2))
+                .has(allOf(counterPoint("my.distribution.histogram", 0), bucket(buckets[0])), atIndex(3))
+                .has(allOf(counterPoint("my.distribution.histogram", 1), bucket(buckets[1])), atIndex(4))
+                .has(allOf(counterPoint("my.distribution.histogram", 2), bucket(buckets[2])), atIndex(5))
+                .has(allOf(counterPoint("my.distribution.histogram", 3), bucket(buckets[3])), atIndex(6))
+                .has(gaugePoint("my.distribution.max", 2000), atIndex(7))
+                .has(counterPoint("my.distribution.totalTime", 2200), atIndex(8));
+
+        distributionSummary.record(5);
+        distributionSummary.record(20);
+        distributionSummary.record(175);
+        distributionSummary.record(2000);
+
+        // Advance time, so we are in the "next" step where currently recorded values will
+        // be reported.
+        mockClock.add(cumulativeHistogramConfig.step());
+
+        assertThat(getDataPoints(registry, mockClock.wallTime())).hasSize(9)
+                .has(gaugePoint("my.distribution.avg", 550), atIndex(0))
+                .has(counterPoint("my.distribution.count", 4), atIndex(1))
+                .has(allOf(counterPoint("my.distribution.histogram", 4), bucket("+Inf")), atIndex(2))
+                .has(allOf(counterPoint("my.distribution.histogram", 0), bucket(buckets[0])), atIndex(3))
+                .has(allOf(counterPoint("my.distribution.histogram", 1), bucket(buckets[1])), atIndex(4))
+                .has(allOf(counterPoint("my.distribution.histogram", 2), bucket(buckets[2])), atIndex(5))
+                .has(allOf(counterPoint("my.distribution.histogram", 3), bucket(buckets[3])), atIndex(6))
                 .has(gaugePoint("my.distribution.max", 2000), atIndex(7))
                 .has(counterPoint("my.distribution.totalTime", 2200), atIndex(8));
 


### PR DESCRIPTION
Current PR adds a new configuration "publishDeltaHistogram" which has higher priority than "publishCumulativeHistogram" when configure both.

The current logic is trivial, and uses the cumulative implementation and calculates delta every time the snapshot is taken, as a diff between the current value and the last snapshot.

Signed-off-by: Bogdan Drutu <bogdandrutu@gmail.com>