### PR TITLE
Use docker cache for gitlab builds

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -7,7 +7,7 @@ include:
     file: '/prodsec/.oss-scan.yml'
 
 image:
-  name: "openjdk:11.0.11-9-jdk"
+  name: "docker-hub.repo.splunkdev.net/openjdk:11.0.11-9-jdk"
 
 stages:
   - build


### PR DESCRIPTION
Reduce the number of `toomanyrequests` failures when building in gitlab.