### PR TITLE
Make retryable exceptions configurable

### DIFF
--- a/signalfx-java/src/main/java/com/signalfx/connection/AbstractHttpReceiverConnection.java
+++ b/signalfx-java/src/main/java/com/signalfx/connection/AbstractHttpReceiverConnection.java
@@ -1,6 +1,7 @@
 package com.signalfx.connection;
 
 import java.io.IOException;
+import java.util.List;
 import java.util.regex.Pattern;
 
 import org.apache.commons.io.IOUtils;
@@ -23,6 +24,7 @@ import com.signalfx.endpoint.SignalFxReceiverEndpoint;
 import com.signalfx.metrics.SignalFxMetricsException;
 
 import static com.signalfx.connection.RetryHandler.DEFAULT_MAX_RETRIES;
+import static com.signalfx.connection.RetryHandler.DEFAULT_NON_RETRYABLE_EXCEPTIONS;
 
 public abstract class AbstractHttpReceiverConnection {
 
@@ -47,9 +49,14 @@ public abstract class AbstractHttpReceiverConnection {
 
     protected AbstractHttpReceiverConnection(SignalFxReceiverEndpoint endpoint, int timeoutMs, int maxRetries,
                                              HttpClientConnectionManager httpClientConnectionManager) {
+        this(endpoint, timeoutMs, DEFAULT_MAX_RETRIES, httpClientConnectionManager, DEFAULT_NON_RETRYABLE_EXCEPTIONS);
+    }
+
+    protected AbstractHttpReceiverConnection(SignalFxReceiverEndpoint endpoint, int timeoutMs, int maxRetries,
+                                             HttpClientConnectionManager httpClientConnectionManager, List<Class<? extends IOException>> nonRetryableExceptions) {
         this.client = HttpClientBuilder.create()
                 .setConnectionManager(httpClientConnectionManager)
-                .setRetryHandler(new RetryHandler(maxRetries))
+                .setRetryHandler(new RetryHandler(maxRetries, nonRetryableExceptions))
                 .setServiceUnavailableRetryStrategy(new RetryStrategy(maxRetries))
                 .build();
         this.host = new HttpHost(endpoint.getHostname(), endpoint.getPort(), endpoint.getScheme());

--- a/signalfx-java/src/main/java/com/signalfx/connection/AbstractHttpReceiverConnection.java
+++ b/signalfx-java/src/main/java/com/signalfx/connection/AbstractHttpReceiverConnection.java
@@ -23,8 +23,8 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.signalfx.endpoint.SignalFxReceiverEndpoint;
 import com.signalfx.metrics.SignalFxMetricsException;
 
-import static com.signalfx.connection.RetryHandler.DEFAULT_MAX_RETRIES;
-import static com.signalfx.connection.RetryHandler.DEFAULT_NON_RETRYABLE_EXCEPTIONS;
+import static com.signalfx.connection.RetryDefaults.DEFAULT_MAX_RETRIES;
+import static com.signalfx.connection.RetryDefaults.DEFAULT_NON_RETRYABLE_EXCEPTIONS;
 
 public abstract class AbstractHttpReceiverConnection {
 

--- a/signalfx-java/src/main/java/com/signalfx/connection/RetryDefaults.java
+++ b/signalfx-java/src/main/java/com/signalfx/connection/RetryDefaults.java
@@ -11,7 +11,7 @@ public final class RetryDefaults {
     private RetryDefaults() {
     }
 
-    public static final Integer DEFAULT_MAX_RETRIES = 3;
+    public static final int DEFAULT_MAX_RETRIES = 3;
     public static final List<Class<? extends IOException>> DEFAULT_NON_RETRYABLE_EXCEPTIONS = Arrays.asList(
             InterruptedIOException.class,
             UnknownHostException.class,

--- a/signalfx-java/src/main/java/com/signalfx/connection/RetryDefaults.java
+++ b/signalfx-java/src/main/java/com/signalfx/connection/RetryDefaults.java
@@ -5,6 +5,7 @@ import java.io.InterruptedIOException;
 import java.net.ConnectException;
 import java.net.UnknownHostException;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 
 public final class RetryDefaults {
@@ -12,8 +13,8 @@ public final class RetryDefaults {
     }
 
     public static final int DEFAULT_MAX_RETRIES = 3;
-    public static final List<Class<? extends IOException>> DEFAULT_NON_RETRYABLE_EXCEPTIONS = Arrays.asList(
+    public static final List<Class<? extends IOException>> DEFAULT_NON_RETRYABLE_EXCEPTIONS = Collections.unmodifiableList(Arrays.asList(
             InterruptedIOException.class,
             UnknownHostException.class,
-            ConnectException.class);
+            ConnectException.class));
 }

--- a/signalfx-java/src/main/java/com/signalfx/connection/RetryDefaults.java
+++ b/signalfx-java/src/main/java/com/signalfx/connection/RetryDefaults.java
@@ -1,0 +1,19 @@
+package com.signalfx.connection;
+
+import java.io.IOException;
+import java.io.InterruptedIOException;
+import java.net.ConnectException;
+import java.net.UnknownHostException;
+import java.util.Arrays;
+import java.util.List;
+
+public final class RetryDefaults {
+    private RetryDefaults() {
+    }
+
+    public static final Integer DEFAULT_MAX_RETRIES = 3;
+    public static final List<Class<? extends IOException>> DEFAULT_NON_RETRYABLE_EXCEPTIONS = Arrays.asList(
+            InterruptedIOException.class,
+            UnknownHostException.class,
+            ConnectException.class);
+}

--- a/signalfx-java/src/main/java/com/signalfx/connection/RetryHandler.java
+++ b/signalfx-java/src/main/java/com/signalfx/connection/RetryHandler.java
@@ -1,9 +1,11 @@
 package com.signalfx.connection;
 
+import java.io.IOException;
 import java.io.InterruptedIOException;
 import java.net.ConnectException;
 import java.net.UnknownHostException;
 import java.util.Arrays;
+import java.util.List;
 
 import org.apache.http.impl.client.DefaultHttpRequestRetryHandler;
 
@@ -15,18 +17,20 @@ import org.apache.http.impl.client.DefaultHttpRequestRetryHandler;
  */
 class RetryHandler extends DefaultHttpRequestRetryHandler {
   public static final Integer DEFAULT_MAX_RETRIES = 3;
+  public static final List<Class<? extends IOException>> DEFAULT_NON_RETRYABLE_EXCEPTIONS = Arrays.asList(
+          InterruptedIOException.class,
+          UnknownHostException.class,
+          ConnectException.class);
 
   public RetryHandler(final int maxRetries) {
-    super(maxRetries, true, Arrays.asList(
-        InterruptedIOException.class,
-        UnknownHostException.class,
-        ConnectException.class));
+    super(maxRetries, true, DEFAULT_NON_RETRYABLE_EXCEPTIONS);
   }
 
   public RetryHandler() {
-    super(DEFAULT_MAX_RETRIES, true, Arrays.asList(
-            InterruptedIOException.class,
-            UnknownHostException.class,
-            ConnectException.class));
+    super(DEFAULT_MAX_RETRIES, true, DEFAULT_NON_RETRYABLE_EXCEPTIONS);
+  }
+
+  public RetryHandler(final int maxRetries, List<Class<? extends IOException>> clazzes) {
+    super(maxRetries, true, clazzes);
   }
 }

--- a/signalfx-java/src/main/java/com/signalfx/connection/RetryHandler.java
+++ b/signalfx-java/src/main/java/com/signalfx/connection/RetryHandler.java
@@ -1,13 +1,12 @@
 package com.signalfx.connection;
 
 import java.io.IOException;
-import java.io.InterruptedIOException;
-import java.net.ConnectException;
-import java.net.UnknownHostException;
-import java.util.Arrays;
 import java.util.List;
 
 import org.apache.http.impl.client.DefaultHttpRequestRetryHandler;
+
+import static com.signalfx.connection.RetryDefaults.DEFAULT_MAX_RETRIES;
+import static com.signalfx.connection.RetryDefaults.DEFAULT_NON_RETRYABLE_EXCEPTIONS;
 
 /**
  * Compared to the {@link DefaultHttpRequestRetryHandler} we allow retry on {@link
@@ -16,18 +15,13 @@ import org.apache.http.impl.client.DefaultHttpRequestRetryHandler;
  * "stale" connections in such a way that http client is unable to detect this.
  */
 class RetryHandler extends DefaultHttpRequestRetryHandler {
-  public static final Integer DEFAULT_MAX_RETRIES = 3;
-  public static final List<Class<? extends IOException>> DEFAULT_NON_RETRYABLE_EXCEPTIONS = Arrays.asList(
-          InterruptedIOException.class,
-          UnknownHostException.class,
-          ConnectException.class);
 
   public RetryHandler(final int maxRetries) {
-    super(maxRetries, true, DEFAULT_NON_RETRYABLE_EXCEPTIONS);
+    this(maxRetries, DEFAULT_NON_RETRYABLE_EXCEPTIONS);
   }
 
   public RetryHandler() {
-    super(DEFAULT_MAX_RETRIES, true, DEFAULT_NON_RETRYABLE_EXCEPTIONS);
+    this(DEFAULT_MAX_RETRIES, DEFAULT_NON_RETRYABLE_EXCEPTIONS);
   }
 
   public RetryHandler(final int maxRetries, List<Class<? extends IOException>> clazzes) {

--- a/signalfx-java/src/main/java/com/signalfx/metrics/connection/AbstractHttpDataPointProtobufReceiverConnection.java
+++ b/signalfx-java/src/main/java/com/signalfx/metrics/connection/AbstractHttpDataPointProtobufReceiverConnection.java
@@ -44,6 +44,15 @@ public abstract class AbstractHttpDataPointProtobufReceiverConnection extends Ab
         this.compress = !Boolean.getBoolean(DISABLE_COMPRESSION_PROPERTY);
     }
 
+    public AbstractHttpDataPointProtobufReceiverConnection(SignalFxReceiverEndpoint endpoint,
+                                                           int timeoutMs,
+                                                           int maxRetries,
+                                                           HttpClientConnectionManager httpClientConnectionManager,
+                                                           List<Class<? extends IOException>> nonRetryableExceptions) {
+        super(endpoint, timeoutMs, maxRetries, httpClientConnectionManager, nonRetryableExceptions);
+        this.compress = !Boolean.getBoolean(DISABLE_COMPRESSION_PROPERTY);
+    }
+
     @Override
     public void addDataPoints(String auth, List<SignalFxProtocolBuffers.DataPoint> dataPoints)
             throws SignalFxMetricsException {

--- a/signalfx-java/src/main/java/com/signalfx/metrics/connection/HttpDataPointProtobufReceiverConnection.java
+++ b/signalfx-java/src/main/java/com/signalfx/metrics/connection/HttpDataPointProtobufReceiverConnection.java
@@ -37,6 +37,12 @@ public class HttpDataPointProtobufReceiverConnection
         super(endpoint, timeoutMs, maxRetries, httpClientConnectionManager);
     }
 
+    public HttpDataPointProtobufReceiverConnection(
+            SignalFxReceiverEndpoint endpoint, int timeoutMs, int maxRetries,
+            HttpClientConnectionManager httpClientConnectionManager, List<Class<? extends IOException>> nonRetryableExceptions) {
+        super(endpoint, timeoutMs, maxRetries, httpClientConnectionManager, nonRetryableExceptions);
+    }
+
     @Override
     protected HttpEntity getEntityForVersion(List<SignalFxProtocolBuffers.DataPoint> dataPoints) {
         return new InputStreamEntity(

--- a/signalfx-java/src/main/java/com/signalfx/metrics/connection/HttpDataPointProtobufReceiverConnectionV2.java
+++ b/signalfx-java/src/main/java/com/signalfx/metrics/connection/HttpDataPointProtobufReceiverConnectionV2.java
@@ -1,5 +1,6 @@
 package com.signalfx.metrics.connection;
 
+import java.io.IOException;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -24,6 +25,12 @@ public class HttpDataPointProtobufReceiverConnectionV2
             SignalFxReceiverEndpoint endpoint, int timeoutMs, int maxRetries,
             HttpClientConnectionManager httpClientConnectionManager) {
         super(endpoint, timeoutMs, maxRetries, httpClientConnectionManager);
+    }
+
+    public HttpDataPointProtobufReceiverConnectionV2(
+            SignalFxReceiverEndpoint endpoint, int timeoutMs, int maxRetries,
+            HttpClientConnectionManager httpClientConnectionManager, List<Class<? extends IOException>> nonRetryableExceptions) {
+        super(endpoint, timeoutMs, maxRetries, httpClientConnectionManager, nonRetryableExceptions);
     }
 
     @Override

--- a/signalfx-java/src/main/java/com/signalfx/metrics/connection/HttpDataPointProtobufReceiverFactory.java
+++ b/signalfx-java/src/main/java/com/signalfx/metrics/connection/HttpDataPointProtobufReceiverFactory.java
@@ -7,6 +7,7 @@ import com.signalfx.endpoint.SignalFxReceiverEndpoint;
 import com.signalfx.metrics.SignalFxMetricsException;
 
 import java.io.IOException;
+import java.util.Collections;
 import java.util.List;
 
 import static com.signalfx.connection.RetryDefaults.DEFAULT_MAX_RETRIES;
@@ -49,7 +50,7 @@ public class HttpDataPointProtobufReceiverFactory implements DataPointReceiverFa
     }
 
     public HttpDataPointProtobufReceiverFactory setNonRetryableExceptions(List<Class<? extends IOException>> clazzes) {
-        this.nonRetryableExceptions = clazzes;
+        this.nonRetryableExceptions = Collections.unmodifiableList(clazzes);
         return this;
     }
 

--- a/signalfx-java/src/main/java/com/signalfx/metrics/connection/HttpDataPointProtobufReceiverFactory.java
+++ b/signalfx-java/src/main/java/com/signalfx/metrics/connection/HttpDataPointProtobufReceiverFactory.java
@@ -7,20 +7,14 @@ import com.signalfx.endpoint.SignalFxReceiverEndpoint;
 import com.signalfx.metrics.SignalFxMetricsException;
 
 import java.io.IOException;
-import java.io.InterruptedIOException;
-import java.net.ConnectException;
-import java.net.UnknownHostException;
-import java.util.Arrays;
 import java.util.List;
+
+import static com.signalfx.connection.RetryDefaults.DEFAULT_MAX_RETRIES;
+import static com.signalfx.connection.RetryDefaults.DEFAULT_NON_RETRYABLE_EXCEPTIONS;
 
 public class HttpDataPointProtobufReceiverFactory implements DataPointReceiverFactory {
     public static final int DEFAULT_TIMEOUT_MS = 2000;
     public static final int DEFAULT_VERSION = 2;
-    public static final int DEFAULT_MAX_RETRIES = 3;
-    public static final List<Class<? extends IOException>> DEFAULT_NON_RETRYABLE_EXCEPTIONS = Arrays.asList(
-            InterruptedIOException.class,
-            UnknownHostException.class,
-            ConnectException.class);
 
     private final SignalFxReceiverEndpoint endpoint;
     private HttpClientConnectionManager httpClientConnectionManager;

--- a/signalfx-java/src/main/java/com/signalfx/metrics/connection/HttpDataPointProtobufReceiverFactory.java
+++ b/signalfx-java/src/main/java/com/signalfx/metrics/connection/HttpDataPointProtobufReceiverFactory.java
@@ -7,6 +7,7 @@ import com.signalfx.endpoint.SignalFxReceiverEndpoint;
 import com.signalfx.metrics.SignalFxMetricsException;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
@@ -50,7 +51,7 @@ public class HttpDataPointProtobufReceiverFactory implements DataPointReceiverFa
     }
 
     public HttpDataPointProtobufReceiverFactory setNonRetryableExceptions(List<Class<? extends IOException>> clazzes) {
-        this.nonRetryableExceptions = Collections.unmodifiableList(clazzes);
+        this.nonRetryableExceptions = Collections.unmodifiableList(new ArrayList<>(clazzes));
         return this;
     }
 

--- a/signalfx-java/src/test/java/com/signalfx/metrics/connection/HttpDataPointProtobufReceiverConnectionTest.java
+++ b/signalfx-java/src/test/java/com/signalfx/metrics/connection/HttpDataPointProtobufReceiverConnectionTest.java
@@ -105,11 +105,11 @@ public class HttpDataPointProtobufReceiverConnectionTest {
     final CountDownLatch latch = new CountDownLatch(1);
     final LatchTriggeredHandler handler = new LatchTriggeredHandler(latch);
     ScheduledThreadPoolExecutor executor = new ScheduledThreadPoolExecutor(1);
-    executor.schedule(latch::countDown, 3000, MILLISECONDS);
+    executor.schedule(latch::countDown, 500, MILLISECONDS);
 
     Server server = new Server();
     ServerConnector connector = new ServerConnector(server);
-    connector.setIdleTimeout(500);
+    connector.setIdleTimeout(100);
     connector.setPort(0);
     server.setConnectors(new Connector[]{connector});
     server.setHandler(handler);
@@ -120,6 +120,7 @@ public class HttpDataPointProtobufReceiverConnectionTest {
       DataPointReceiver dpr = new HttpDataPointProtobufReceiverFactory(
               new SignalFxEndpoint(uri.getScheme(), uri.getHost(), uri.getPort()))
               .setMaxRetries(1)
+              .setTimeoutMs(50)
               .setNonRetryableExceptions(Collections.emptyList())
               .createDataPointReceiver();
       try {
@@ -137,11 +138,11 @@ public class HttpDataPointProtobufReceiverConnectionTest {
     final CountDownLatch latch = new CountDownLatch(1);
     final LatchTriggeredHandler handler = new LatchTriggeredHandler(latch);
     ScheduledThreadPoolExecutor executor = new ScheduledThreadPoolExecutor(1);
-    executor.schedule(latch::countDown, 2000, MILLISECONDS);
+    executor.schedule(latch::countDown, 500, MILLISECONDS);
 
     Server server = new Server();
     ServerConnector connector = new ServerConnector(server);
-    connector.setIdleTimeout(500);
+    connector.setIdleTimeout(100);
     connector.setPort(0);
     server.setConnectors(new Connector[]{connector});
     server.setHandler(handler);
@@ -151,6 +152,7 @@ public class HttpDataPointProtobufReceiverConnectionTest {
       URI uri = server.getURI();
       DataPointReceiver dpr = new HttpDataPointProtobufReceiverFactory(
               new SignalFxEndpoint(uri.getScheme(), uri.getHost(), uri.getPort()))
+              .setTimeoutMs(50)
               .setMaxRetries(1)
               .createDataPointReceiver();
       try {


### PR DESCRIPTION
### Context

Recently we've been seeing read socket timeouts from SignalFx on our end. We've increased the timeout of the connection to 15 seconds, however we are still seeing `SocketTimeoutException` which leads to data loss. To circumvent this and prevent data loss, we would like to retry on this exception. Therefore, I have made the list of exceptions to retry on configurable, with a default list which replicates the previous behaviour

### Changes implemented

- Add configurable exceptions to retry logic via constructor overloading for the datapoints API