### PR TITLE
Strip leading v in version string passed by user

### DIFF
--- a/update_version.py
+++ b/update_version.py
@@ -84,5 +84,6 @@ if __name__ == '__main__':
         sys.exit(1)
 
     version = sys.argv[1]
+    version = re.sub(r'^v', '', version)
     update_pom_files(version)
     perform_file_replacements(version)


### PR DESCRIPTION
The update version script does not expect the leading `v`. Strip it if the user passes it in, rather than inserting inconsistent version strings everywhere.