### PR TITLE
Enable retries on 429 in retry handler

### DIFF
--- a/signalfx-java/src/main/java/com/signalfx/connection/RetryStrategy.java
+++ b/signalfx-java/src/main/java/com/signalfx/connection/RetryStrategy.java
@@ -15,7 +15,7 @@ public class RetryStrategy implements ServiceUnavailableRetryStrategy {
     @Override
     public boolean retryRequest(final HttpResponse httpResponse, final int executionCount, final HttpContext httpContext) {
         final int statusCode = httpResponse.getStatusLine().getStatusCode();
-        return executionCount <= maxRetries && (statusCode == HttpStatus.SC_REQUEST_TIMEOUT || statusCode == HttpStatus.SC_GATEWAY_TIMEOUT || statusCode == 598 || statusCode == -1);
+        return executionCount <= maxRetries && (statusCode == HttpStatus.SC_REQUEST_TIMEOUT || statusCode == HttpStatus.SC_GATEWAY_TIMEOUT || statusCode == 598 || statusCode == -1 || statusCode == HttpStatus.SC_TOO_MANY_REQUESTS);
     }
 
     @Override

--- a/signalfx-java/src/test/java/com/signalfx/connection/RetryStrategyTest.java
+++ b/signalfx-java/src/test/java/com/signalfx/connection/RetryStrategyTest.java
@@ -58,6 +58,17 @@ public class RetryStrategyTest {
     }
 
     @Test
+    public void shouldSetRetryOnTooManyRequests() {
+        final RetryStrategy retryStrategy = new RetryStrategy(3);
+
+        final StatusLine mockStatusLine = generateStatusLineByCode(HttpStatus.SC_TOO_MANY_REQUESTS);
+        final HttpContext mockHttpContext = new HttpClientContext();
+        final HttpResponse mockResp = DefaultHttpResponseFactory.INSTANCE.newHttpResponse(mockStatusLine, mockHttpContext);
+
+        assertTrue(retryStrategy.retryRequest(mockResp, 1, mockHttpContext));
+    }
+
+    @Test
     public void shouldNotRetryOnOtherStatusCode() {
         final RetryStrategy retryStrategy = new RetryStrategy(3);
 


### PR DESCRIPTION
## Context
In #245, a retry strategy that copied the behaviour of the golang multitoken sink implementation was added. This PR addresses a bug within the strategy. In the golang multitoken sink, a `429` response would actually result in a status code of `-1` in the golang struct for storing status codes, resulting in a retry. I can elaborate on the implementation if you would like that context.

In the current implementation, the `429` is not mapped to `-1`, and will therefore not result in a retry.

## Changes

- Add explicit retry on 429s