### PR TITLE
Move httpclient dependency up to indicate that it is not a test depen…

### DIFF
--- a/signalfx-connection/pom.xml
+++ b/signalfx-connection/pom.xml
@@ -55,14 +55,14 @@
       <groupId>commons-io</groupId>
       <artifactId>commons-io</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.apache.httpcomponents</groupId>
+      <artifactId>httpclient</artifactId>
+    </dependency>
     <!-- test -->
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.httpcomponents</groupId>
-      <artifactId>httpclient</artifactId>
     </dependency>
   </dependencies>
 </project>


### PR DESCRIPTION
…dency
junit is put to test scope via dependencyManagement in root pom