### PR TITLE
Add 1 year deprecations for yammer and codahale

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,11 @@ to Splunk instead.
 
 Legacy documentation is still here for posterity: [legacy-usage.md](legacy-usage.md). 
 
+## Deprecations
+
+* :warning: `signalfx-codahale` will be deleted in July 2024.
+* :warning: `signalfx-yammer` will be deleted in July 2024. 
+
 # Executing SignalFlow computations
 
 [Learn more about using SignalFlow here](signalflow.md).

--- a/signalfx-codahale/README.md
+++ b/signalfx-codahale/README.md
@@ -1,0 +1,11 @@
+
+# signalfx-codahale
+
+:warning: `signalfx-codahale` has been deprecated and will be deleted
+in July 2024. No further releases will be available after June 2024.
+
+Users are encouraged to use the
+[OpenTelemetry Java SDK](https://github.com/open-telemetry/opentelemetry-java) or the 
+[Splunk Distribution of OpenTelemetry Java Instrumentation](https://github.com/signalfx/splunk-otel-java)
+to send metrics to Splunk.
+

--- a/signalfx-codahale/src/main/java/com/signalfx/codahale/SfxMetrics.java
+++ b/signalfx-codahale/src/main/java/com/signalfx/codahale/SfxMetrics.java
@@ -33,9 +33,9 @@ import com.signalfx.metrics.protobuf.SignalFxProtocolBuffers;
 
 /**
  * A utility class for declaring Codahale metrics with additional dimensions.
- *
- * @author max
+ * @deprecated Migrate to OpenTelemetry to send metric telemetry to Splunk.
  */
+@Deprecated
 public class SfxMetrics {
 
     private final MetricRegistry metricRegistry;

--- a/signalfx-codahale/src/main/java/com/signalfx/codahale/metrics/ResettingHistogram.java
+++ b/signalfx-codahale/src/main/java/com/signalfx/codahale/metrics/ResettingHistogram.java
@@ -20,7 +20,6 @@ import com.codahale.metrics.ResettingExponentiallyDecayingReservoir;
  * histo.update(42);
  * </pre>
  *
- * @author max
  * @see com.codahale.metrics.Histogram
  */
 public class ResettingHistogram extends Histogram {

--- a/signalfx-codahale/src/main/java/com/signalfx/codahale/metrics/ResettingTimer.java
+++ b/signalfx-codahale/src/main/java/com/signalfx/codahale/metrics/ResettingTimer.java
@@ -20,7 +20,6 @@ import com.codahale.metrics.Timer;
  * }
  * </pre>
  *
- * @author uday
  */
 public class ResettingTimer extends Timer {
 

--- a/signalfx-codahale/src/main/java/com/signalfx/codahale/reporter/DimensionInclusion.java
+++ b/signalfx-codahale/src/main/java/com/signalfx/codahale/reporter/DimensionInclusion.java
@@ -8,8 +8,6 @@ import com.signalfx.metrics.protobuf.SignalFxProtocolBuffers;
 /**
  * Collection of flags to indicate if a default dimension should be added to a type of metric
  *
- * @author tedo
- *
  */
 public class DimensionInclusion {
 

--- a/signalfx-codahale/src/main/java/com/signalfx/codahale/reporter/SignalFxReporter.java
+++ b/signalfx-codahale/src/main/java/com/signalfx/codahale/reporter/SignalFxReporter.java
@@ -37,7 +37,9 @@ import com.signalfx.metrics.protobuf.SignalFxProtocolBuffers;
 /**
  * Reporter object for codahale metrics that reports values to com.signalfx.signalfx at some
  * interval.
+ * @deprecated Migrate to OpenTelemetry to send metric telemetry to Splunk.
  */
+@Deprecated
 public class SignalFxReporter extends ScheduledReporter {
     private final AggregateMetricSender aggregateMetricSender;
     private final Set<MetricDetails> detailsToAdd;

--- a/signalfx-codahale/src/main/java/com/signalfx/codahale/util/BasicJvmMetrics.java
+++ b/signalfx-codahale/src/main/java/com/signalfx/codahale/util/BasicJvmMetrics.java
@@ -25,8 +25,6 @@ import com.codahale.metrics.MetricRegistry;
 /**
  * Report a basic set of JVM metrics to SignalFx.
  *
- * @author psi
- *
  */
 public class BasicJvmMetrics {
     /**

--- a/signalfx-yammer/README.md
+++ b/signalfx-yammer/README.md
@@ -1,0 +1,11 @@
+
+# signalfx-yammer
+
+:warning: `signalfx-yammer` has been deprecated and will be deleted
+in July 2024. No further releases will be available after June 2024.
+
+Users are encouraged to use the
+[OpenTelemetry Java SDK](https://github.com/open-telemetry/opentelemetry-java) or the 
+[Splunk Distribution of OpenTelemetry Java Instrumentation](https://github.com/signalfx/splunk-otel-java)
+to send metrics to Splunk.
+

--- a/signalfx-yammer/src/main/java/com/signalfx/codahale/reporter/SfUtil.java
+++ b/signalfx-yammer/src/main/java/com/signalfx/codahale/reporter/SfUtil.java
@@ -8,7 +8,9 @@ import com.signalfx.metrics.protobuf.SignalFxProtocolBuffers;
 
 /**
  * Utility functions that make common SignalFx operations easier to do.
+ * @deprecated Migrate to OpenTelemetry to send metric telemetry to Splunk.
  */
+@Deprecated
 public class SfUtil {
 
     /**

--- a/signalfx-yammer/src/main/java/com/signalfx/codahale/reporter/SignalFxReporter.java
+++ b/signalfx-yammer/src/main/java/com/signalfx/codahale/reporter/SignalFxReporter.java
@@ -34,7 +34,9 @@ import com.yammer.metrics.core.Timer;
 /**
  * Reporter object for codahale metrics that reports values to com.signalfx.signalfx at some
  * interval.
+ * @deprecated Migrate to OpenTelemetry to send metric telemetry to Splunk.
  */
+@Deprecated
 public class SignalFxReporter extends CustomScheduledReporter {
     private final AggregateMetricSender aggregateMetricSender;
     private final Set<MetricDetails> detailsToAdd;


### PR DESCRIPTION
Users are now encouraged to switch to OpenTelemetry to send metrics to Splunk o11y (formerly SignalFx).

Code will be removed from this repo in July 2024 and no more releases will be created thereafter.