### PR TITLE
Support timezone param for WebSocketTransport execute

### DIFF
--- a/signalfx-signalflow/src/main/java/com/signalfx/signalflow/SignalFlowClient.java
+++ b/signalfx-signalflow/src/main/java/com/signalfx/signalflow/SignalFlowClient.java
@@ -56,7 +56,7 @@ public class SignalFlowClient implements AutoCloseable {
 
     /**
      * This method is deprecated and will be removed in the next major release. Use
-     * {@link #execute(String, Long, Long, Long, Long, Boolean, Boolean)} instead
+     * {@link #execute(String, Long, Long, Long, Long, Boolean, Boolean, String)} instead
      * 
      * Execute the given SignalFlow program with parameters and stream the output back.
      *
@@ -77,7 +77,38 @@ public class SignalFlowClient implements AutoCloseable {
     @Deprecated
     public Computation execute(String program, long start, long stop, long resolution,
                                long maxDelay, boolean persistent) {
-        return execute(program, start, stop, resolution, maxDelay, persistent, false);
+        return execute(program, start, stop, resolution, maxDelay, persistent, false, null);
+    }
+
+    /**
+     * This method is deprecated and will be removed in the next major release. Use
+     * {@link #execute(String, Long, Long, Long, Long, Boolean, Boolean, String)} instead
+     *
+     * @param program
+     *            computation written in signalflow language
+     * @param start
+     *            Optional timestamp in milliseconds since epoch. Defaults to the current timestamp.
+     * @param stop
+     *            Optional timestamp in milliseconds since epoch. Defaults to infinity.
+     * @param resolution
+     *            Optional the minimum desired data resolution, in milliseconds. This allows the
+     *            client to put an upper bound on the number of datapoints in the computation
+     *            output.
+     * @param maxDelay
+     *            Optional desired maximum data delay, in milliseconds between 1 and 900000. When
+     *            set to zero or unset, max delay will be evaluated dynamically based on the
+     *            historical lag information of the input data.
+     * @param persistent
+     *            Optional persistent setting
+     * @param immediate
+     *            Optional adjusts the stop timestamp so that the computation doesn't wait for
+     *            future data to be available
+     * @return computation instance
+     */
+    @Deprecated
+    public Computation execute(String program, Long start, Long stop, Long resolution,
+                               Long maxDelay, Boolean persistent, Boolean immediate) {
+        return execute(program, start, stop, resolution, maxDelay, persistent, immediate, null);
     }
 
     /**
@@ -102,12 +133,14 @@ public class SignalFlowClient implements AutoCloseable {
      * @param immediate
      *            Optional adjusts the stop timestamp so that the computation doesn't wait for
      *            future data to be available
+     * @param timeZone
+     *            Optional the timezone to be used for computation
      * @return computation instance
      */
     public Computation execute(String program, Long start, Long stop, Long resolution,
-                               Long maxDelay, Boolean persistent, Boolean immediate) {
+                               Long maxDelay, Boolean persistent, Boolean immediate, String timeZone) {
         Map<String, String> params = buildParams("start", start, "stop", stop, "resolution",
-                resolution, "maxDelay", maxDelay, "persistent", persistent, "immediate", immediate);
+                resolution, "maxDelay", maxDelay, "persistent", persistent, "immediate", immediate, "timezone", timeZone);
         return new Computation(this.transport, program, params, false);
     }
 

--- a/signalfx-signalflow/src/main/java/com/signalfx/signalflow/SignalFlowClient.java
+++ b/signalfx-signalflow/src/main/java/com/signalfx/signalflow/SignalFlowClient.java
@@ -134,7 +134,8 @@ public class SignalFlowClient implements AutoCloseable {
      *            Optional adjusts the stop timestamp so that the computation doesn't wait for
      *            future data to be available
      * @param timeZone
-     *            Optional the timezone to be used for computation
+     *            Optional the time zone to be used for computation. The value is forwarded to the endpoint.
+     *            Supported time zone values are mentioned in the <a href="https://dev.splunk.com/observability/docs/time_zone">docs.</a>
      * @return computation instance
      */
     public Computation execute(String program, Long start, Long stop, Long resolution,


### PR DESCRIPTION
The SignaFlow client for java does not have a way to specify the timezone while the signalfx-python lib does. We would like to have similar capabilities.